### PR TITLE
Show error message when usage data fails to load (#43)

### DIFF
--- a/vscode-extension/media/app.js
+++ b/vscode-extension/media/app.js
@@ -218,6 +218,14 @@ async function loadData() {
     updateTimeScopeCounts()
   } catch (e) {
     console.error('Failed to load data:', e)
+    const pace = document.getElementById('usage-pace')
+    const canvas = document.getElementById('usage-chart')
+    if (pace) pace.innerHTML = ''
+    if (canvas) {
+      canvas.style.display = 'none'
+      canvas.parentElement.querySelector('h3').insertAdjacentHTML('afterend',
+        '<div class="empty-state-box"><div class="empty-state-icon">⚠️</div><p class="empty-state">Failed to load usage data. Ensure ccusage is installed (npx ccusage) and try the Refresh button on the Usage tab.</p></div>')
+    }
   }
 }
 

--- a/webapp/static/app.js
+++ b/webapp/static/app.js
@@ -234,6 +234,14 @@ async function loadData() {
     updateTimeScopeCounts()
   } catch (e) {
     console.error('Failed to load data:', e)
+    const pace = document.getElementById('usage-pace')
+    const canvas = document.getElementById('usage-chart')
+    if (pace) pace.innerHTML = ''
+    if (canvas) {
+      canvas.style.display = 'none'
+      canvas.parentElement.querySelector('h3').insertAdjacentHTML('afterend',
+        '<div class="empty-state-box"><div class="empty-state-icon">⚠️</div><p class="empty-state">Failed to load usage data. Ensure ccusage is installed (npx ccusage) and try the Refresh button on the Usage tab.</p></div>')
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

When `loadData()` fails (ccusage not installed, network error, etc.), the Usage tab now shows a helpful error message instead of staying blank: "Failed to load usage data. Ensure ccusage is installed (npx ccusage) and try the Refresh button on the Usage tab."

Applied to both webapp and VS Code extension (feature parity).

## Test plan

- [x] All 416 tests pass
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)