### PR TITLE
Add health endpoint, PR template, and E2E smoke test checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Summary
+<!-- 1-3 bullet points describing what this PR does -->
+
+## Test plan
+- [ ] Unit tests pass: `npm test` (vscode-extension) and `uv run pytest tests/` (webapp)
+- [ ] E2E smoke test via Playwright MCP (see CLAUDE.md checklist) — required for UI/API changes
+- [ ] No security regressions (XSS, injection, path traversal)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,9 +196,10 @@ The webapp uses a project dropdown (populated from session data) to scope featur
 
 ## Production Standards
 - **All new features must have tests.** No merging without test coverage for the change.
-- **Security:** All user-controlled strings rendered in HTML must pass through `escapeHtml()`. All shell commands must use `execFileSync` with argument arrays, never string interpolation. XSS and injection tests exist and must stay green.
-- **No regressions:** `npm test` must pass (currently 465 tests) before any commit to main.
+- **Security:** All user-controlled strings rendered in HTML must pass through `escapeHtml()`. All shell commands must use `execFileSync` with argument arrays, never string interpolation. Error messages must pass through `_sanitize_error()` / `sanitizeError()` to redact API keys. XSS and injection tests exist and must stay green.
+- **No regressions:** `npm test` must pass (currently 466 tests) before any commit to main.
 - **Feature parity:** Both the VS Code extension and the webapp are production deliverables. New scoring/analytics features should be implemented in both. Security fixes (XSS, injection) apply to both `media/app.js` and `webapp/static/app.js`.
+- **E2E testing:** Every PR test plan must include manual Playwright MCP smoke testing of the webapp before merging. See the E2E Smoke Test Checklist below.
 
 ## JSONL Data Format (VERIFIED against real data)
 
@@ -382,7 +383,7 @@ Fixed brand colors (semantic meaning, don't change with theme):
 ## Testing
 ```bash
 cd vscode-extension
-npm test                   # Runs all 465 Jest tests (12 suites)
+npm test                   # Runs all 466 Jest tests (12 suites)
 
 # Test structure:
 # test/unit/prompts.test.ts                    — prompt loader + template filler (all prompt types)
@@ -398,4 +399,26 @@ npm test                   # Runs all 465 Jest tests (12 suites)
 # test/integration/extension.test.ts           — activation, status bar, commands
 # test/integration/webviewProvider.test.ts      — message handling, HTML generation, injection tests, optimizer IPC
 # test/__mocks__/vscode.ts                     — VS Code API mock for Jest
+
+cd ../webapp
+uv run pytest tests/ -v    # Runs all webapp tests (106 tests, 4 suites)
+
+# Test structure:
+# tests/test_api.py        — health endpoint, sessions, scores, scoring, optimizer, quickwins, usage
+# tests/test_helpers.py    — _decode_project_path, _detect_project_repo, validators, compute_aggregate, classify_error
+# tests/test_security.py   — rate limiting, CORS, error leakage, path traversal, security headers
+# tests/conftest.py        — shared fixtures (TestClient, mock Anthropic, mock sessions)
 ```
+
+### E2E Smoke Test Checklist (Playwright MCP)
+
+Run before merging PRs that touch webapp UI or API. Start the server with `uv run uvicorn main:app --port 8001`, then verify:
+
+1. **Tab navigation** — all 5 tabs switch correctly, correct panel is visible
+2. **Settings bar visibility** — data path input shows only on Fluency Score; project dropdown shows on Fluency Score, Optimizer, Quick Wins; settings bar hidden on Recommendations, Usage
+3. **Project dropdown** — populates from session data when data path is set
+4. **Fluency scoring** — Run Scoring button triggers analysis, results display with score ring and behavior bars
+5. **Prompt Optimizer** — paste prompt, click Optimize, input/output scores and optimized prompt appear
+6. **Quick Wins** — Generate button works; project-scoped mode uses selected project
+7. **Usage tab** — data renders with pace cards and chart (if ccusage data exists)
+8. **Health endpoint** — `GET /health` returns status, version, and dependency checks

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -197,6 +197,41 @@ DATA_DIR = Path(__file__).parent.parent / "data"
 CCUSAGE_DIR = DATA_DIR / "ccusage"
 
 
+def _get_version() -> str:
+    """Read version from pyproject.toml."""
+    pyproject = Path(__file__).parent / "pyproject.toml"
+    if pyproject.exists():
+        for line in pyproject.read_text().splitlines():
+            if line.strip().startswith("version"):
+                return line.split("=")[1].strip().strip('"')
+    return "unknown"
+
+
+APP_VERSION = _get_version()
+
+
+@app.get("/health")
+async def health():
+    """Health check endpoint for monitoring."""
+    checks = {}
+
+    # Check Anthropic API key is configured
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    checks["anthropic_api_key"] = "configured" if api_key else "missing"
+
+    # Check default data directory is accessible
+    default_data_dir = Path.home() / ".claude" / "projects"
+    checks["data_directory"] = "accessible" if default_data_dir.is_dir() else "not_found"
+
+    status = "ok" if checks["anthropic_api_key"] == "configured" else "degraded"
+
+    return {
+        "status": status,
+        "version": APP_VERSION,
+        "checks": checks,
+    }
+
+
 @app.get("/api/usage")
 async def get_usage():
     """Serve ccusage JSON data directly."""

--- a/webapp/tests/test_api.py
+++ b/webapp/tests/test_api.py
@@ -10,6 +10,33 @@ import main
 from tests.conftest import make_anthropic_response, _mock_project_encoded
 
 
+class TestHealth:
+    def test_returns_status_and_version(self, client):
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "status" in data
+        assert "version" in data
+        assert "checks" in data
+        assert data["status"] in ("ok", "degraded")
+
+    def test_reports_api_key_status(self, client, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+        resp = client.get("/health")
+        assert resp.json()["checks"]["anthropic_api_key"] == "configured"
+
+    def test_reports_missing_api_key(self, client, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        resp = client.get("/health")
+        data = resp.json()
+        assert data["checks"]["anthropic_api_key"] == "missing"
+        assert data["status"] == "degraded"
+
+    def test_includes_data_directory_check(self, client):
+        resp = client.get("/health")
+        assert resp.json()["checks"]["data_directory"] in ("accessible", "not_found")
+
+
 class TestGetBenchmarks:
     def test_returns_benchmark_data(self, client):
         resp = client.get("/api/benchmarks")


### PR DESCRIPTION
## Summary
- Add `GET /health` endpoint returning status, version, and dependency checks (API key configured, data directory accessible)
- Add PR template with E2E smoke test reminder for UI/API changes
- Add E2E smoke test checklist to CLAUDE.md for manual Playwright MCP testing before merging
- Update CLAUDE.md with current test counts and security control documentation

## Test plan
- [x] Unit tests pass: `npm test` (466 tests) and `uv run pytest tests/` (106 tests)
- [x] CI passes on PR
- [x] `GET /health` returns `{"status": "ok", "version": "0.1.0", "checks": {...}}`

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)