### PR TITLE
Fix repo detection for dotted names (.github.io)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ npm test                   # Jest (unit + integration, 468 tests)
 
 # Package and install
 npx @vscode/vsce package --allow-missing-repository
-code --install-extension codefluent-0.2.0.vsix
+code --install-extension codefluent-0.2.1.vsix
 
 # Debug: press F5 in VS Code with vscode-extension/ open
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cd codefluent/vscode-extension
 npm install
 npm run compile
 npx @vscode/vsce package --allow-missing-repository
-code --install-extension codefluent-0.2.0.vsix
+code --install-extension codefluent-0.2.1.vsix
 ```
 
 **Windows (PowerShell):**
@@ -72,7 +72,7 @@ cd codefluent\vscode-extension
 npm install
 npm run compile
 npx @vscode/vsce package --allow-missing-repository
-code --install-extension codefluent-0.2.0.vsix
+code --install-extension codefluent-0.2.1.vsix
 ```
 
 Then reload VS Code. The CodeFluent icon appears in the activity bar.

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -18,7 +18,7 @@ CodeFluent parses your local Claude Code session files, scores your prompts agai
 
 1. Install the `.vsix` package:
    ```
-   code --install-extension codefluent-0.2.0.vsix
+   code --install-extension codefluent-0.2.1.vsix
    ```
 2. Open the CodeFluent sidebar by clicking the activity bar icon
 3. When prompted, enter your Anthropic API key (stored securely in VS Code SecretStorage)

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "codefluent",
   "displayName": "CodeFluent",
   "description": "Claude Code analytics dashboard — AI fluency scoring, usage tracking, and recommendations",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "frederick-douglas-pearce",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {

--- a/vscode-extension/src/quickwins.ts
+++ b/vscode-extension/src/quickwins.ts
@@ -93,7 +93,7 @@ export function detectWorkspaceRepo(workspacePath?: string): { owner: string; na
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim()
     // Handle both HTTPS (https://github.com/owner/repo.git) and SSH (git@github.com:owner/repo.git)
-    const match = remoteUrl.match(/github\.com[:/]([^/]+)\/([^/.]+)/)
+    const match = remoteUrl.match(/github\.com[:/]([^/]+)\/([^/]+?)(?:\.git)?$/)
     if (match) {
       return { owner: validateGitHubName(match[1]), name: validateGitHubName(match[2]) }
     }

--- a/vscode-extension/test/unit/quickwins.test.ts
+++ b/vscode-extension/test/unit/quickwins.test.ts
@@ -61,6 +61,22 @@ describe('detectWorkspaceRepo', () => {
     expect(result).toEqual({ owner: 'myowner', name: 'myrepo' })
   })
 
+  it('parses GitHub Pages repo with dots in name', () => {
+    mockExecFileSync.mockReturnValue('https://github.com/myowner/myowner.github.io.git\n')
+
+    const result = detectWorkspaceRepo('/some/path')
+
+    expect(result).toEqual({ owner: 'myowner', name: 'myowner.github.io' })
+  })
+
+  it('parses HTTPS remote URL without .git suffix', () => {
+    mockExecFileSync.mockReturnValue('https://github.com/myowner/myrepo\n')
+
+    const result = detectWorkspaceRepo('/some/path')
+
+    expect(result).toEqual({ owner: 'myowner', name: 'myrepo' })
+  })
+
   it('uses execFileSync with arg array (not shell string)', () => {
     mockExecFileSync.mockReturnValue('https://github.com/owner/repo.git\n')
 

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -1042,7 +1042,7 @@ def _detect_project_repo(project_dir: str) -> dict | None:
         )
         if result.returncode != 0:
             return None
-        match = re.match(r".*github\.com[:/]([^/]+)/([^/.]+)", result.stdout.strip())
+        match = re.match(r".*github\.com[:/]([^/]+)/([^/]+?)(?:\.git)?$", result.stdout.strip())
         if match:
             return {"owner": match.group(1), "name": match.group(2)}
     except Exception:

--- a/webapp/pyproject.toml
+++ b/webapp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codefluent"
-version = "0.2.0"
+version = "0.2.1"
 description = "Personal AI fluency analytics for Claude Code users"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/webapp/tests/test_helpers.py
+++ b/webapp/tests/test_helpers.py
@@ -95,6 +95,24 @@ class TestDetectProjectRepo:
         with patch("main.subprocess.run", return_value=mock_result):
             assert _detect_project_repo("/nonexistent") is None
 
+    def test_detects_dotted_repo_name(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "https://github.com/owner/owner.github.io.git"
+
+        with patch("main.subprocess.run", return_value=mock_result):
+            result = _detect_project_repo("/home/user/project")
+            assert result == {"owner": "owner", "name": "owner.github.io"}
+
+    def test_detects_https_without_git_suffix(self):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "https://github.com/owner/repo-name"
+
+        with patch("main.subprocess.run", return_value=mock_result):
+            result = _detect_project_repo("/home/user/project")
+            assert result == {"owner": "owner", "name": "repo-name"}
+
     def test_returns_none_for_non_github(self):
         mock_result = MagicMock()
         mock_result.returncode = 0

--- a/webapp/uv.lock
+++ b/webapp/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "codefluent"
-version = "0.2.0"
+version = "0.2.1"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Fix regex in `detectWorkspaceRepo` (extension) and `_detect_project_repo` (webapp) that broke Quick Wins for repos with dots in the name (e.g., `owner.github.io`)
- The old regex `[^/.]+` stopped at dots; new regex captures the full name and strips `.git` suffix separately
- Bumps version to 0.2.1

Fixes #83

## Test plan
- [x] 470 extension tests pass (2 new: dotted repo name, no .git suffix)
- [x] 196 webapp tests pass (2 new: dotted repo name, no .git suffix)
- [x] CI passes
- [x] Manual test: Quick Wins works on frederick-douglas-pearce.github.io repo
- [ ] After merge: tag `v0.2.1`, verify release pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)