### PR TITLE
Fix sparkline score history not scoped to current project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ npm run compile            # One-shot TypeScript compilation
 npm run watch              # Continuous compilation
 
 # Test
-npm test                   # Jest (unit + integration, 468 tests)
+npm test                   # Jest (unit + integration, 471 tests)
 
 # Package and install
 npx @vscode/vsce package --allow-missing-repository
@@ -189,7 +189,7 @@ The webapp uses a project dropdown (populated from session data) to scope featur
 - **Commit to feature/fix branches freely** — push often, squash or merge to main via PR.
 
 ### CI Workflows
-- **`ci.yml`** — Runs on every PR: `npm test` (468 tests) in `vscode-extension/`, `pytest` (194 tests) in `webapp/`
+- **`ci.yml`** — Runs on every PR: `npm test` (471 tests) in `vscode-extension/`, `pytest` (198 tests) in `webapp/`
 - **`security-review.yml`** — Runs on every PR: grep-based checks for security anti-patterns (inline onclick, string interpolation in shell commands, missing escapeHtml)
 - **`claude-review.yml`** — AI code review via `claude-code-action@v1`. Triggered by `needs-review` label on PR (not on every push, to control API costs). Also responds to `@claude` mentions in PR comments.
 - **`release.yml`** — Release workflow for publishing
@@ -197,7 +197,7 @@ The webapp uses a project dropdown (populated from session data) to scope featur
 ## Production Standards
 - **All new features must have tests.** No merging without test coverage for the change.
 - **Security:** All user-controlled strings rendered in HTML must pass through `escapeHtml()`. All shell commands must use `execFileSync` with argument arrays, never string interpolation. Error messages must pass through `_sanitize_error()` / `sanitizeError()` to redact API keys. XSS and injection tests exist and must stay green.
-- **No regressions:** `npm test` must pass (currently 468 tests) before any commit to main.
+- **No regressions:** `npm test` must pass (currently 471 tests) before any commit to main.
 - **Feature parity:** Both the VS Code extension and the webapp are production deliverables. New scoring/analytics features should be implemented in both. Security fixes (XSS, injection) apply to both `media/app.js` and `webapp/static/app.js`.
 - **E2E testing:** Every PR test plan must include manual Playwright MCP smoke testing of the webapp before merging. See the E2E Smoke Test Checklist below.
 
@@ -383,7 +383,7 @@ Fixed brand colors (semantic meaning, don't change with theme):
 ## Testing
 ```bash
 cd vscode-extension
-npm test                   # Runs all 466 Jest tests (12 suites)
+npm test                   # Runs all 471 Jest tests (12 suites)
 
 # Test structure:
 # test/unit/prompts.test.ts                    — prompt loader + template filler (all prompt types)
@@ -401,7 +401,7 @@ npm test                   # Runs all 466 Jest tests (12 suites)
 # test/__mocks__/vscode.ts                     — VS Code API mock for Jest
 
 cd ../webapp
-uv run pytest tests/ -v    # Runs all webapp tests (194 tests, 5 suites)
+uv run pytest tests/ -v    # Runs all webapp tests (198 tests, 5 suites)
 
 # Test structure:
 # tests/test_api.py              — health endpoint, sessions, scores, scoring, optimizer, quickwins, usage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ For the web app, see [`webapp/README.md`](webapp/README.md).
 
 ```bash
 cd vscode-extension
-npm test                        # Run all 468 tests across 12 suites
+npm test                        # Run all 471 tests across 12 suites
 npx jest --coverage             # Run with coverage report
 npx jest test/unit/scoring      # Run a specific test file
 ```
@@ -114,7 +114,7 @@ CodeFluent ships **two production interfaces**: the VS Code extension and the we
 
 Before submitting a pull request, verify:
 
-- [ ] `npm test` passes (all 313+ tests green)
+- [ ] `npm test` passes (all 471+ tests green)
 - [ ] No regressions in existing functionality
 - [ ] New features include test coverage
 - [ ] Both interfaces updated if the change affects shared functionality

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Everything runs locally. No data leaves your machine except the API calls to Ant
 | Input validation | Pydantic constraints, length limits, path checks | Oversized payloads, path traversal |
 | Rate limiting | 10 req/min sliding window (webapp) | API abuse |
 | CORS | Localhost-only default (webapp) | Unauthorized cross-origin access |
-| Automated testing | 662 tests including security-focused suites | Regressions |
+| Automated testing | 669 tests including security-focused suites | Regressions |
 | CI security review | Claude security review on PRs | New vulnerabilities |
 
 All user-controlled strings are escaped before rendering in HTML. Shell commands use argument arrays (`execFileSync`) instead of string interpolation. The webapp validates all inputs with Pydantic models and enforces rate limits. Security-focused test suites verify XSS and injection protections.
@@ -287,7 +287,7 @@ npm run watch          # Continuous TypeScript compilation
 
 Four GitHub Actions workflows run automatically:
 
-- **CI** (`ci.yml`) — Runs on PRs + pushes to main. Compiles TypeScript, runs all 468 extension tests + 194 webapp tests. Must pass to merge.
+- **CI** (`ci.yml`) — Runs on PRs + pushes to main. Compiles TypeScript, runs all 471 extension tests + 198 webapp tests. Must pass to merge.
 - **Claude Code Review** (`claude-review.yml`) — AI-powered PR review on all PRs, responds to `@claude` mentions.
 - **Security Review** (`security-review.yml`) — Claude-based security scan on PRs, checks for XSS/injection vectors.
 - **Release** (`release.yml`) — Triggered by version tags (`v*`). Builds VSIX and creates GitHub Release.
@@ -295,7 +295,7 @@ Four GitHub Actions workflows run automatically:
 ### Testing
 
 ```bash
-npm test               # Run all Jest tests (468 tests across 12 suites)
+npm test               # Run all Jest tests (471 tests across 12 suites)
 ```
 
 ### Packaging

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "codefluent",
   "displayName": "CodeFluent",
   "description": "Claude Code analytics dashboard — AI fluency scoring, usage tracking, and recommendations",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publisher": "frederick-douglas-pearce",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {

--- a/vscode-extension/src/webviewProvider.ts
+++ b/vscode-extension/src/webviewProvider.ts
@@ -261,7 +261,11 @@ export class CodeFluentViewProvider implements vscode.WebviewViewProvider {
     const aggregate = scored.length ? computeAggregate(scored, configBehaviors) : {} as any
     aggregate.sessions_requested = sessionIds.length
     aggregate.sessions_skipped = sessionIds.length - scored.length
-    aggregate.score_history = computeScoreHistory(cached, sessions, configBehaviors)
+    const projectName = this.getWorkspaceProjectName()
+    const projectSessions = projectName
+      ? sessions.filter((s: any) => s.project === projectName)
+      : sessions
+    aggregate.score_history = computeScoreHistory(cached, projectSessions, configBehaviors)
 
     this.updateStatusBar(aggregate)
 

--- a/vscode-extension/test/integration/webviewProvider.test.ts
+++ b/vscode-extension/test/integration/webviewProvider.test.ts
@@ -536,6 +536,36 @@ describe('CodeFluentViewProvider', () => {
         true,
       )
     })
+
+    it('scopes score_history to workspace project sessions only', async () => {
+      ;(vscode.workspace as any).workspaceFolders = [
+        { uri: vscode.Uri.file('/home/user/my-project') },
+      ]
+      const sessions = [
+        { id: 'sess-1', project: 'my-project', user_prompts: ['hi'], started_at: '2026-03-01T00:00:00Z' },
+        { id: 'sess-2', project: 'other-project', user_prompts: ['bye'], started_at: '2026-02-15T00:00:00Z' },
+      ]
+      ;(getAllSessions as jest.Mock).mockReturnValue({ sessions })
+      ;(scoreSessions as jest.Mock).mockResolvedValue({
+        'sess-1': { session_id: 'sess-1', fluency_behaviors: { clarifying_goals: true } },
+      })
+      ;(computeAggregate as jest.Mock).mockReturnValue({ average_score: 80, sessions_scored: 1 })
+      ;(computeScoreHistory as jest.Mock).mockReturnValue([])
+
+      await sendMessage({
+        type: 'runScoring',
+        requestId: 'req-history',
+        payload: { session_ids: ['sess-1'] },
+      })
+
+      // computeScoreHistory should only receive my-project sessions, not other-project
+      expect(computeScoreHistory).toHaveBeenCalledWith(
+        expect.any(Object),
+        [expect.objectContaining({ id: 'sess-1', project: 'my-project' })],
+        undefined,
+      )
+      ;(vscode.workspace as any).workspaceFolders = undefined
+    })
   })
 
   describe('message handling: getQuickwins', () => {

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -104,6 +104,7 @@ SINGLE_SCORING_PROMPT_VERSION = _single_scoring_prompt["version"]
 class ScoreRequest(BaseModel):
     session_ids: list[str] = Field(..., min_length=1, max_length=500)
     force_rescore: bool = False
+    project: str = Field(default="", max_length=500)
 
     @field_validator("session_ids", mode="before")
     @classmethod
@@ -321,7 +322,7 @@ async def get_sessions(
 
 
 @app.get("/api/scores")
-async def get_scores():
+async def get_scores(project: str = Query(default=None, max_length=500)):
     """Return cached fluency scores scoped to last-scored sessions."""
     scores_path = DATA_DIR / "scores.json"
     if not scores_path.exists():
@@ -357,10 +358,12 @@ async def get_scores():
         aggregate["sessions_requested"] = len(last_ids)
         aggregate["sessions_skipped"] = len(last_ids) - len(scored)
 
-    # Attach score history from all cached scores + sessions
+    # Attach score history scoped to project
     data_dir = _resolve_data_dir()
     session_data = get_all_sessions(data_dir)
     sessions_list = session_data.get("sessions", [])
+    if project:
+        sessions_list = [s for s in sessions_list if s.get("project") == project]
     aggregate["score_history"] = compute_score_history(cached, sessions_list, config_behaviors)
 
     return {"scores": scoped, "aggregate": aggregate}
@@ -475,8 +478,11 @@ async def score_sessions(request: ScoreRequest):
     aggregate = compute_aggregate(scored, config_behaviors) if scored else {}
     aggregate["sessions_requested"] = len(session_ids)
     aggregate["sessions_skipped"] = len(session_ids) - len(scored)
+    history_sessions = list(all_sessions.values())
+    if request.project:
+        history_sessions = [s for s in history_sessions if s.get("project") == request.project]
     aggregate["score_history"] = compute_score_history(
-        cached, list(all_sessions.values()), config_behaviors
+        cached, history_sessions, config_behaviors
     )
 
     return {"scores": results, "aggregate": aggregate}

--- a/webapp/pyproject.toml
+++ b/webapp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codefluent"
-version = "0.2.1"
+version = "0.2.2"
 description = "Personal AI fluency analytics for Claude Code users"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/webapp/static/app.js
+++ b/webapp/static/app.js
@@ -698,7 +698,7 @@ async function runScoring(scopeValue) {
     const res = await fetch('/api/score', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ session_ids: ids, force_rescore: forceRescore })
+      body: JSON.stringify({ session_ids: ids, force_rescore: forceRescore, project: getSelectedProject() })
     })
     state.scores = await res.json()
     renderFluencyScore()
@@ -1176,7 +1176,9 @@ function renderRecCard(rec) {
 // --- Load cached scores ---
 async function loadCachedScores() {
   try {
-    const res = await fetch('/api/scores')
+    const project = getSelectedProject()
+    const url = project ? `/api/scores?project=${encodeURIComponent(project)}` : '/api/scores'
+    const res = await fetch(url)
     const data = await res.json()
     if (data.aggregate?.average_score) {
       state.scores = data

--- a/webapp/tests/test_api.py
+++ b/webapp/tests/test_api.py
@@ -168,6 +168,52 @@ class TestGetScores:
         data = resp.json()
         assert "session-1" in data["scores"]
 
+    def test_score_history_scoped_to_project(self, client, tmp_path, monkeypatch):
+        """Score history should only include sessions from the requested project."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(exist_ok=True)
+        monkeypatch.setattr(main, "DATA_DIR", data_dir)
+
+        scores = {
+            "sess-a": {
+                "session_id": "sess-a",
+                "fluency_behaviors": {b: True for b in main.BEHAVIORS},
+                "overall_score": 90,
+                "prompt_version": main.SCORING_PROMPT_VERSION,
+            },
+            "sess-b": {
+                "session_id": "sess-b",
+                "fluency_behaviors": {b: False for b in main.BEHAVIORS},
+                "overall_score": 10,
+                "prompt_version": main.SCORING_PROMPT_VERSION,
+            },
+        }
+        (data_dir / "scores.json").write_text(json.dumps(scores))
+        (data_dir / "last_scored_ids.json").write_text(json.dumps(["sess-a", "sess-b"]))
+
+        # Mock sessions: two projects, different weeks
+        sessions = [
+            {"id": "sess-a", "project": "my-app", "user_prompts": ["hi"], "started_at": "2026-03-01T00:00:00Z"},
+            {"id": "sess-b", "project": "other-app", "user_prompts": ["bye"], "started_at": "2026-02-15T00:00:00Z"},
+        ]
+        monkeypatch.setattr(main, "_resolve_data_dir", lambda data_path=None: tmp_path / "sessions")
+        monkeypatch.setattr(main, "get_all_sessions", lambda *a, **kw: {"sessions": sessions, "metadata": {}})
+
+        # Without project filter: both sessions contribute to history
+        resp = client.get("/api/scores")
+        assert resp.status_code == 200
+        history_all = resp.json()["aggregate"]["score_history"]
+
+        # With project filter: only my-app session contributes
+        resp = client.get("/api/scores", params={"project": "my-app"})
+        assert resp.status_code == 200
+        history_scoped = resp.json()["aggregate"]["score_history"]
+
+        assert len(history_scoped) <= len(history_all)
+        # All scoped history entries should only come from the week of sess-a
+        for entry in history_scoped:
+            assert entry["period"] == "2026-W09"  # Week of March 1, 2026
+
 
 class TestPostScore:
     def test_validates_empty_session_ids(self, client):
@@ -242,6 +288,39 @@ class TestPostScore:
         assert resp.json()["scores"]["cached-session"]["overall_score"] == 80
         # Should NOT have called the API since score was cached
         mock_anthropic.messages.create.assert_not_called()
+
+    def test_score_history_scoped_to_project(self, client, tmp_path, monkeypatch, mock_anthropic):
+        """POST /api/score should scope score_history to the requested project."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(exist_ok=True)
+        monkeypatch.setattr(main, "DATA_DIR", data_dir)
+
+        # Pre-cache scores for two sessions in different projects
+        cached = {
+            "sess-a": {
+                "session_id": "sess-a",
+                "fluency_behaviors": {b: True for b in main.BEHAVIORS},
+                "overall_score": 90,
+                "prompt_version": main.SCORING_PROMPT_VERSION,
+            },
+        }
+        (data_dir / "scores.json").write_text(json.dumps(cached))
+
+        sessions = [
+            {"id": "sess-a", "project": "my-app", "user_prompts": ["hi"], "started_at": "2026-03-01T00:00:00Z"},
+            {"id": "sess-b", "project": "other-app", "user_prompts": ["bye"], "started_at": "2026-02-15T00:00:00Z"},
+        ]
+        monkeypatch.setattr(main, "_resolve_data_dir", lambda data_path=None: tmp_path / "sess_dir")
+        monkeypatch.setattr(main, "get_all_sessions", lambda *a, **kw: {"sessions": sessions, "metadata": {}})
+        (tmp_path / "sess_dir").mkdir()
+
+        # Score with project filter
+        resp = client.post("/api/score", json={"session_ids": ["sess-a"], "project": "my-app"})
+        assert resp.status_code == 200
+        history = resp.json()["aggregate"]["score_history"]
+        # History should only contain weeks from my-app sessions
+        for entry in history:
+            assert entry["period"] == "2026-W09"
 
 
 class TestPostOptimize:

--- a/webapp/uv.lock
+++ b/webapp/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "codefluent"
-version = "0.2.1"
+version = "0.2.2"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- **Bug:** Sparkline chart and "Up from X last week" trend text showed score history from ALL projects instead of only the current workspace project. A user with 1 session in a new repo would see trends from their other projects.
- **Root cause:** `computeScoreHistory` was called with unfiltered sessions in `handleRunScoring` (VS Code) and both `/api/score` + `/api/scores` (webapp). The `getCachedScores` path already had the fix but the other code paths didn't.
- **Fix:** Filter sessions to the active project before computing score history in all three code paths. Added `project` parameter to webapp `ScoreRequest` model and `GET /api/scores` endpoint. Updated webapp frontend to pass the selected project.
- Bumps version to 0.2.2.

## Test plan
- [x] `npm test` passes (471 tests)
- [x] `uv run pytest tests/ -v` passes (198 tests)
- [x] Manual: Open VS Code extension in a workspace with only 1 scored session — sparkline should show a single data point, no "Up from X" trend text
- [x] Manual: Open VS Code extension in a workspace with multiple weeks of scored sessions — sparkline should only reflect that project's history
- [x] Manual: Webapp — select a project in dropdown, run scoring, verify sparkline only shows that project's weekly scores
- [x] Manual: Webapp — load cached scores with project selected, verify history is scoped
- [x] E2E smoke test checklist (Playwright MCP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)