### PR TITLE
Webapp API endpoint for session token analytics

### DIFF
--- a/webapp/main.py
+++ b/webapp/main.py
@@ -321,6 +321,124 @@ async def get_sessions(
     return get_all_sessions(data_dir, limit, project)
 
 
+@app.get("/api/session-analytics")
+async def get_session_analytics(
+    data_path: str = Query(default=None, max_length=1000),
+    project: str = Query(default=None, max_length=500),
+):
+    """Return sessions with token analytics and optional cached fluency scores."""
+    try:
+        data_dir = _resolve_data_dir(data_path)
+        session_data = get_all_sessions(data_dir, project=project)
+        sessions_list = session_data.get("sessions", [])
+
+        # Load cached scores
+        scores_path = DATA_DIR / "scores.json"
+        cached_scores = {}
+        if scores_path.exists():
+            try:
+                with open(scores_path) as f:
+                    cached_scores = json.load(f)
+            except Exception:
+                pass
+
+        # Build session analytics with token data + optional score
+        analytics_sessions = []
+        for s in sessions_list:
+            score_entry = cached_scores.get(s["id"], {})
+            overall_score = None
+            if "overall_score" in score_entry and score_entry.get("prompt_version") == SCORING_PROMPT_VERSION:
+                overall_score = score_entry["overall_score"]
+
+            analytics_sessions.append({
+                "session_id": s["id"],
+                "project": s.get("project", ""),
+                "started_at": s.get("started_at"),
+                "prompt_count": len(s.get("user_prompts", [])),
+                "total_tokens": s.get("total_tokens", 0),
+                "total_input_tokens": s.get("total_input_tokens", 0),
+                "total_output_tokens": s.get("total_output_tokens", 0),
+                "total_cache_creation_tokens": s.get("total_cache_creation_tokens", 0),
+                "total_cache_read_tokens": s.get("total_cache_read_tokens", 0),
+                "tokens_per_prompt": s.get("tokens_per_prompt", 0),
+                "cache_hit_rate": s.get("cache_hit_rate", 0),
+                "overall_score": overall_score,
+            })
+
+        # Compute aggregates
+        aggregates = _compute_session_aggregates(analytics_sessions)
+
+        # Compute weekly breakdown
+        weekly = _compute_weekly_analytics(analytics_sessions)
+
+        return {
+            "sessions": analytics_sessions,
+            "aggregates": aggregates,
+            "weekly": weekly,
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=_sanitize_error(str(e)))
+
+
+def _compute_session_aggregates(sessions: list) -> dict:
+    """Compute aggregate token metrics across sessions."""
+    n = len(sessions)
+    if n == 0:
+        return {
+            "avg_tokens_per_session": 0,
+            "avg_tokens_per_prompt": 0,
+            "avg_cache_hit_rate": 0,
+            "total_sessions": 0,
+        }
+
+    total_tokens_sum = sum(s["total_tokens"] for s in sessions)
+    tokens_per_prompt_values = [s["tokens_per_prompt"] for s in sessions if s["tokens_per_prompt"] > 0]
+    cache_hit_values = [s["cache_hit_rate"] for s in sessions if s["cache_hit_rate"] > 0]
+
+    return {
+        "avg_tokens_per_session": round(total_tokens_sum / n),
+        "avg_tokens_per_prompt": round(sum(tokens_per_prompt_values) / len(tokens_per_prompt_values)) if tokens_per_prompt_values else 0,
+        "avg_cache_hit_rate": round(sum(cache_hit_values) / len(cache_hit_values), 2) if cache_hit_values else 0,
+        "total_sessions": n,
+    }
+
+
+def _compute_weekly_analytics(sessions: list) -> list:
+    """Compute weekly token analytics breakdown."""
+    week_groups: dict[str, dict] = {}
+
+    for s in sessions:
+        if not s.get("started_at"):
+            continue
+        week_info = _get_iso_week_key(s["started_at"])
+        if not week_info:
+            continue
+        week_key, _ = week_info
+        if week_key not in week_groups:
+            week_groups[week_key] = {"sessions": []}
+        week_groups[week_key]["sessions"].append(s)
+
+    weekly = []
+    for week_key, group in week_groups.items():
+        week_sessions = group["sessions"]
+        n = len(week_sessions)
+        total_tokens = sum(s["total_tokens"] for s in week_sessions)
+        cache_hit_values = [s["cache_hit_rate"] for s in week_sessions if s["cache_hit_rate"] > 0]
+
+        weekly.append({
+            "week": week_key,
+            "total_tokens": total_tokens,
+            "avg_tokens_per_session": round(total_tokens / n) if n else 0,
+            "avg_cache_hit_rate": round(sum(cache_hit_values) / len(cache_hit_values), 2) if cache_hit_values else 0,
+            "session_count": n,
+        })
+
+    weekly.sort(key=lambda w: w["week"])
+    return weekly
+
+
 @app.get("/api/scores")
 async def get_scores(project: str = Query(default=None, max_length=500)):
     """Return cached fluency scores scoped to last-scored sessions."""

--- a/webapp/tests/test_api.py
+++ b/webapp/tests/test_api.py
@@ -534,6 +534,237 @@ class TestGetQuickwins:
             assert "error" in data
 
 
+class TestSessionAnalytics:
+    def test_returns_sessions_with_token_data(self, client, mock_sessions_dir):
+        resp = client.get("/api/session-analytics", params={"data_path": str(mock_sessions_dir)})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "sessions" in data
+        assert "aggregates" in data
+        assert "weekly" in data
+        assert len(data["sessions"]) == 1
+        session = data["sessions"][0]
+        assert session["session_id"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        assert session["project"] == "testproject"
+        assert session["prompt_count"] == 2
+        assert "total_tokens" in session
+        assert "total_input_tokens" in session
+        assert "total_output_tokens" in session
+        assert "total_cache_creation_tokens" in session
+        assert "total_cache_read_tokens" in session
+        assert "tokens_per_prompt" in session
+        assert "cache_hit_rate" in session
+
+    def test_overall_score_null_when_not_scored(self, client, mock_sessions_dir):
+        resp = client.get("/api/session-analytics", params={"data_path": str(mock_sessions_dir)})
+        assert resp.status_code == 200
+        session = resp.json()["sessions"][0]
+        assert session["overall_score"] is None
+
+    def test_joins_cached_scores(self, client, mock_sessions_dir, tmp_path, monkeypatch):
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(exist_ok=True)
+        monkeypatch.setattr(main, "DATA_DIR", data_dir)
+
+        session_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        scores = {
+            session_id: {
+                "session_id": session_id,
+                "fluency_behaviors": {b: False for b in main.BEHAVIORS},
+                "overall_score": 65,
+                "coding_pattern": "conceptual_inquiry",
+                "prompt_version": main.SCORING_PROMPT_VERSION,
+            }
+        }
+        (data_dir / "scores.json").write_text(json.dumps(scores))
+
+        resp = client.get("/api/session-analytics", params={"data_path": str(mock_sessions_dir)})
+        assert resp.status_code == 200
+        session = resp.json()["sessions"][0]
+        assert session["overall_score"] == 65
+
+    def test_ignores_stale_scores(self, client, mock_sessions_dir, tmp_path, monkeypatch):
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(exist_ok=True)
+        monkeypatch.setattr(main, "DATA_DIR", data_dir)
+
+        session_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        scores = {
+            session_id: {
+                "session_id": session_id,
+                "fluency_behaviors": {b: False for b in main.BEHAVIORS},
+                "overall_score": 65,
+                "coding_pattern": "conceptual_inquiry",
+                "prompt_version": "stale-version-v0.0",
+            }
+        }
+        (data_dir / "scores.json").write_text(json.dumps(scores))
+
+        resp = client.get("/api/session-analytics", params={"data_path": str(mock_sessions_dir)})
+        assert resp.status_code == 200
+        session = resp.json()["sessions"][0]
+        assert session["overall_score"] is None
+
+    def test_respects_project_filter(self, client, mock_sessions_dir):
+        resp = client.get("/api/session-analytics", params={
+            "data_path": str(mock_sessions_dir),
+            "project": "testproject",
+        })
+        assert resp.status_code == 200
+        sessions = resp.json()["sessions"]
+        assert len(sessions) == 1
+        assert sessions[0]["project"] == "testproject"
+
+    def test_project_filter_no_match(self, client, mock_sessions_dir):
+        resp = client.get("/api/session-analytics", params={
+            "data_path": str(mock_sessions_dir),
+            "project": "nonexistent",
+        })
+        assert resp.status_code == 200
+        assert resp.json()["sessions"] == []
+        assert resp.json()["aggregates"]["total_sessions"] == 0
+
+    def test_aggregates_computed(self, client, mock_sessions_dir):
+        resp = client.get("/api/session-analytics", params={"data_path": str(mock_sessions_dir)})
+        assert resp.status_code == 200
+        agg = resp.json()["aggregates"]
+        assert agg["total_sessions"] == 1
+        assert "avg_tokens_per_session" in agg
+        assert "avg_tokens_per_prompt" in agg
+        assert "avg_cache_hit_rate" in agg
+
+    def test_weekly_breakdown_computed(self, client, mock_sessions_dir):
+        resp = client.get("/api/session-analytics", params={"data_path": str(mock_sessions_dir)})
+        assert resp.status_code == 200
+        weekly = resp.json()["weekly"]
+        assert len(weekly) >= 1
+        entry = weekly[0]
+        assert "week" in entry
+        assert "total_tokens" in entry
+        assert "avg_tokens_per_session" in entry
+        assert "avg_cache_hit_rate" in entry
+        assert "session_count" in entry
+
+    def test_sessions_sorted_by_started_at_descending(self, client, mock_sessions_dir, tmp_path):
+        # Create a second session with an earlier date
+        project = mock_sessions_dir / _mock_project_encoded()
+        home = str(Path.home())
+        session2_lines = [
+            {
+                "type": "user",
+                "sessionId": "11111111-2222-3333-4444-555555555555",
+                "cwd": f"{home}/testproject",
+                "message": {"role": "user", "content": "Earlier session"},
+                "timestamp": "2026-02-15T10:00:00.000Z",
+            },
+            {
+                "type": "assistant",
+                "message": {
+                    "model": "claude-sonnet-4-20250514",
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Response"}],
+                    "usage": {"input_tokens": 200, "output_tokens": 100,
+                              "cache_creation_input_tokens": 500, "cache_read_input_tokens": 300},
+                },
+                "timestamp": "2026-02-15T10:00:05.000Z",
+            },
+        ]
+        with open(project / "11111111-2222-3333-4444-555555555555.jsonl", "w") as f:
+            for line in session2_lines:
+                f.write(json.dumps(line) + "\n")
+
+        resp = client.get("/api/session-analytics", params={"data_path": str(mock_sessions_dir)})
+        assert resp.status_code == 200
+        sessions = resp.json()["sessions"]
+        assert len(sessions) == 2
+        # First session should be more recent (March > February)
+        assert sessions[0]["started_at"] > sessions[1]["started_at"]
+
+    def test_rejects_relative_data_path(self, client):
+        resp = client.get("/api/session-analytics", params={"data_path": "relative/path"})
+        assert resp.status_code == 400
+        assert "absolute" in resp.json()["detail"].lower()
+
+    def test_rejects_nonexistent_data_path(self, client, tmp_path):
+        nonexistent = tmp_path / "does_not_exist"
+        resp = client.get("/api/session-analytics", params={"data_path": str(nonexistent)})
+        assert resp.status_code == 400
+
+    def test_returns_empty_for_empty_dir(self, client, tmp_path):
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        resp = client.get("/api/session-analytics", params={"data_path": str(empty_dir)})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["sessions"] == []
+        assert data["aggregates"]["total_sessions"] == 0
+        assert data["weekly"] == []
+
+    def test_weekly_sorted_chronologically(self, client, mock_sessions_dir, tmp_path):
+        # Add a session in a different week
+        project = mock_sessions_dir / _mock_project_encoded()
+        home = str(Path.home())
+        session2_lines = [
+            {
+                "type": "user",
+                "sessionId": "22222222-3333-4444-5555-666666666666",
+                "cwd": f"{home}/testproject",
+                "message": {"role": "user", "content": "Older session"},
+                "timestamp": "2026-02-01T10:00:00.000Z",
+            },
+            {
+                "type": "assistant",
+                "message": {
+                    "model": "claude-sonnet-4-20250514",
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Response"}],
+                    "usage": {"input_tokens": 50, "output_tokens": 25},
+                },
+                "timestamp": "2026-02-01T10:00:05.000Z",
+            },
+        ]
+        with open(project / "22222222-3333-4444-5555-666666666666.jsonl", "w") as f:
+            for line in session2_lines:
+                f.write(json.dumps(line) + "\n")
+
+        resp = client.get("/api/session-analytics", params={"data_path": str(mock_sessions_dir)})
+        assert resp.status_code == 200
+        weekly = resp.json()["weekly"]
+        assert len(weekly) == 2
+        # Should be sorted chronologically (earlier week first)
+        assert weekly[0]["week"] < weekly[1]["week"]
+
+    def test_token_data_from_session(self, client, mock_sessions_dir):
+        """Token fields should reflect actual parsed data from JSONL."""
+        resp = client.get("/api/session-analytics", params={"data_path": str(mock_sessions_dir)})
+        assert resp.status_code == 200
+        session = resp.json()["sessions"][0]
+        # The mock session has input_tokens=100, output_tokens=50
+        assert session["total_input_tokens"] == 100
+        assert session["total_output_tokens"] == 50
+        assert session["total_tokens"] == 150  # 100 + 50 + 0 + 0
+
+    def test_aggregates_empty_sessions(self, client, tmp_path):
+        """Empty session list should return zero aggregates."""
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        resp = client.get("/api/session-analytics", params={"data_path": str(empty_dir)})
+        assert resp.status_code == 200
+        agg = resp.json()["aggregates"]
+        assert agg["avg_tokens_per_session"] == 0
+        assert agg["avg_tokens_per_prompt"] == 0
+        assert agg["avg_cache_hit_rate"] == 0
+        assert agg["total_sessions"] == 0
+
+    def test_default_data_path(self, client, monkeypatch):
+        """Without data_path param, uses default resolution."""
+        monkeypatch.setattr(main, "_resolve_data_dir", lambda data_path=None: Path("/tmp/nonexistent"))
+        monkeypatch.setattr(main, "get_all_sessions", lambda *a, **kw: {"sessions": [], "metadata": {}})
+        resp = client.get("/api/session-analytics")
+        assert resp.status_code == 200
+        assert resp.json()["sessions"] == []
+
+
 class TestGetUsage:
     def test_returns_empty_when_no_data(self, client):
         resp = client.get("/api/usage")


### PR DESCRIPTION
## Summary

Closes #87

Add `GET /api/session-analytics` endpoint that returns per-session token data with optional fluency score joining, aggregates, and weekly breakdown.

- New endpoint with `data_path` and `project` query params
- Joins sessions with cached scores from `data/scores.json` (respects prompt version for staleness)
- Computes aggregates: avg tokens/session, avg tokens/prompt, avg cache hit rate
- Weekly token breakdown using existing `_get_iso_week_key()` pattern
- All error paths through `_sanitize_error()`

## Test plan

- [x] Endpoint returns correct response shape with token fields
- [x] Score joining: scored sessions get `overall_score`, unscored get null
- [x] Stale scores (wrong prompt version) filtered out
- [x] Project filtering via `project` param works
- [x] Sessions sorted by `started_at` descending
- [x] Path validation rejects invalid data paths
- [x] Empty sessions return zeroed aggregates
- [x] Weekly breakdown groups by ISO week correctly
- [x] All existing tests pass (no regressions)
- [x] 222 total tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)