### PR TITLE
ci: add eval regression checks on prompt changes

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,0 +1,27 @@
+name: Eval
+
+on:
+  pull_request:
+    paths:
+      - 'shared/prompts/**'
+
+jobs:
+  eval:
+    name: Scoring Regression Checks
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        working-directory: webapp
+        run: uv sync --extra dev
+
+      - name: Run eval checks
+        working-directory: webapp
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: uv run python ../shared/eval/run_eval.py --check all --sections single_scoring,config_scoring --verbose


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/eval.yml` that runs scoring schema + agreement checks when PRs modify `shared/prompts/**`
- Scoped to `single_scoring` + `config_scoring` sections (33 entries, ~$0.10-0.15 per run)
- Skipped for Dependabot PRs (no access to repo secrets)
- Existing `ci.yml` unchanged — eval unit tests already run there via `uv run pytest tests/`

Closes #122

## Test plan

- [x] Workflow file is valid (GitHub parses it without error)
- [x] Workflow does NOT trigger on this PR (no changes to `shared/prompts/`)
- [x] Existing CI checks (`ci.yml`, `security-review.yml`) still pass
- [x] Verify `ANTHROPIC_API_KEY` repo secret exists (required for eval runs)
- [x] Manual: test PR #125 touching `shared/prompts/registry.json` triggered eval workflow — 33/33 schema pass, 90.6% agreement, ~$0.14 cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)