### PR TITLE
docs: update project docs for eval framework and CI workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,14 +80,23 @@ codefluent/
 ├── shared/
 │   ├── benchmarks.json        # Benchmark data
 │   ├── pricing.json           # Token pricing by model (input/output/cache rates)
-│   └── prompts/               # Versioned prompt templates
-│       ├── registry.json          # Active version pointers
-│       ├── scoring/v1.0.md        # Session scoring prompt
-│       ├── config/v1.0.md         # CLAUDE.md scoring prompt
-│       ├── optimizer/v1.1.md      # Prompt optimizer prompt (config-aware)
-│       └── single_scoring/v1.0.md # Single-prompt verification scorer
+│   ├── prompts/               # Versioned prompt templates
+│   │   ├── registry.json          # Active version pointers
+│   │   ├── scoring/v1.0.md        # Session scoring prompt
+│   │   ├── config/v1.0.md         # CLAUDE.md scoring prompt
+│   │   ├── optimizer/v1.1.md      # Prompt optimizer prompt (config-aware)
+│   │   └── single_scoring/v1.0.md # Single-prompt verification scorer
+│   └── eval/                  # Scoring regression testing framework
+│       ├── README.md              # Golden set + eval runner docs
+│       ├── golden_set.json        # 50 curated regression test cases
+│       ├── run_eval.py            # CLI entry point (argparse)
+│       ├── scorer.py              # Prompt loading, API calls, retry
+│       ├── checks.py              # 5 check implementations
+│       ├── report.py              # JSON + stdout output, cost tracking
+│       └── results/               # Output directory (gitignored)
 ├── .github/workflows/         # CI/CD
 │   ├── ci.yml                 # Tests + lint on PR
+│   ├── eval.yml               # Scoring regression checks on prompt changes
 │   ├── claude-review.yml      # AI code review (needs-review label)
 │   ├── security-review.yml    # Security-focused review
 │   ├── release.yml            # Build VSIX + publish on tag
@@ -97,6 +106,26 @@ codefluent/
 ├── data/                      # Generated data (gitignored)
 └── images/                    # Demo screenshots
 ```
+
+## Documentation Map
+
+When adding features or changing architecture, check this list for files that may need updating.
+
+| File | Purpose | Update when... |
+|------|---------|----------------|
+| `CLAUDE.md` | AI coding instructions, architecture, conventions, commands | Adding files, commands, test suites, or CI workflows |
+| `README.md` | Public-facing project overview, features, setup, eval framework | Adding user-visible features, changing test counts, updating setup steps |
+| `vscode-extension/README.md` | Extension setup, features, screenshots, marketplace listing | Changing extension features, installation steps, or screenshots |
+| `webapp/README.md` | Webapp setup, design choices, security, testing | Changing webapp features, test counts, security controls, or API surface |
+| `shared/eval/README.md` | Golden set structure, eval runner CLI, checks, CI integration | Changing eval checks, CLI options, test counts, or CI workflow |
+| `CONTRIBUTING.md` | Dev setup, code conventions, PR checklist, security rules | Changing dev workflow, conventions, or review requirements |
+| `docs/PROJECT_PLAN.md` | Master plan and milestones | Completing milestones or changing project direction |
+| `docs/TECHNICAL_SPEC.md` | Implementation spec (scoring, analytics, caching) | Changing scoring logic, API surface, or data flow |
+| `docs/UI_SPEC.md` | Frontend design spec (both interfaces) | Changing UI layout, components, or interaction patterns |
+| `docs/SESSION_DATA.md` | JSONL data format, availability, scope | Changing parser behavior or supported data formats |
+| `docs/REFERENCES.md` | Research papers and external docs links | Adding new research foundations or external references |
+| `docs/DEMO_SCRIPT.md` | 3-minute demo walkthrough | Changing demo flow or feature highlights |
+| Memory files (`~/.claude/projects/.../memory/`) | Test counts, lessons learned, project phase | Changing test counts, learning new project conventions |
 
 ## Key Commands
 ```bash
@@ -126,6 +155,14 @@ uv sync
 npx ccusage@latest daily --json > ../data/ccusage/daily.json
 uv run python extract_prompts.py
 uv run uvicorn main:app --reload --host 0.0.0.0 --port 8000
+
+# --- Eval Runner ---
+
+cd webapp
+uv run python ../shared/eval/run_eval.py --dry-run           # Preview (no API calls)
+uv run python ../shared/eval/run_eval.py                      # Schema + agreement checks
+uv run python ../shared/eval/run_eval.py --check consistency  # Self-consistency check
+uv run python ../shared/eval/run_eval.py --verbose            # Verbose output
 ```
 
 ## Extension Architecture
@@ -223,7 +260,8 @@ chore: bump @anthropic-ai/sdk to 0.52.0
 4. Release Please creates the git tag → triggers `release.yml` → builds VSIX → publishes to Marketplace
 
 ### CI Workflows
-- **`ci.yml`** — Runs on every PR: `npm test` (528 tests) in `vscode-extension/`, `pytest` (241 tests) in `webapp/`
+- **`ci.yml`** — Runs on every PR: `npm test` (528 tests) in `vscode-extension/`, `pytest` (320 tests) in `webapp/`
+- **`eval.yml`** — Runs on PRs touching `shared/prompts/**`: scores golden set (33 entries) via Anthropic API, validates schema + agreement (~$0.15/run). Skipped for Dependabot.
 - **`security-review.yml`** — Runs on every PR: grep-based checks for security anti-patterns (inline onclick, string interpolation in shell commands, missing escapeHtml)
 - **`claude-review.yml`** — AI code review via `claude-code-action@v1`. Triggered by `needs-review` label on PR (not on every push, to control API costs). Also responds to `@claude` mentions in PR comments.
 - **`release.yml`** — Triggered by version tags: builds VSIX, publishes to Marketplace, uploads to GitHub Release
@@ -438,7 +476,7 @@ npm test                   # Runs all 528 Jest tests (14 suites)
 # test/__mocks__/vscode.ts                     — VS Code API mock for Jest
 
 cd ../webapp
-uv run pytest tests/ -v    # Runs all webapp tests (241 tests, 5 suites)
+uv run pytest tests/ -v    # Runs all webapp tests (320 tests, 6 suites)
 
 # Test structure:
 # tests/test_api.py              — health endpoint, sessions, scores, scoring, optimizer, quickwins, usage
@@ -446,6 +484,7 @@ uv run pytest tests/ -v    # Runs all webapp tests (241 tests, 5 suites)
 # tests/test_security.py         — rate limiting, CORS, error leakage, path traversal, security headers, XSS source-level verification
 # tests/test_extract_prompts.py  — JSONL parsing, content extraction, session filtering, metadata
 # tests/test_prompts.py          — prompt loading, template filling, registry consistency
+# tests/test_eval.py             — eval framework (scorer, checks, report, CLI, golden set integration)
 # tests/conftest.py              — shared fixtures (TestClient, mock Anthropic, mock sessions)
 ```
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,51 @@ The extension resolves this automatically via the system home directory.
 
 Everything runs locally. No data leaves your machine except the API calls to Anthropic for scoring.
 
+## Eval Framework
+
+CodeFluent uses an LLM-as-judge architecture — an LLM scores user prompts against 11 fluency behaviors. This creates a challenge: how do you ensure scoring quality doesn't degrade when you update prompt templates, switch models, or add new LLM providers?
+
+The eval framework (`shared/eval/`) solves this with a golden set of 50 human-labeled entries and an automated regression runner that validates scoring outputs before changes ship. As CodeFluent expands beyond Claude to support additional LLM providers, the eval framework provides the ground truth needed to validate that scoring remains accurate and consistent across models.
+
+### Golden Set
+
+50 curated entries across 4 scoring sections, each with human-verified expected behaviors and rationale:
+
+| Section | Entries | What it validates |
+|---------|---------|-------------------|
+| Single-prompt scoring | 25 | Behavior classification across the full score range (0–100) |
+| Session scoring | 12 | Multi-prompt sessions with metadata signals (plan mode, tools, thinking) |
+| Config scoring | 8 | CLAUDE.md files testing behavior credit boundaries |
+| Optimizer | 5 | Input scoring accuracy and config-aware skip logic |
+
+Entries span web dev, data science, systems programming, mobile, infrastructure, and edge cases (injection attempts, code-only prompts, ambiguous requests).
+
+### Automated Checks
+
+The eval runner (`run_eval.py`) implements 5 checks:
+
+| Check | What it measures | When to use |
+|-------|-----------------|-------------|
+| **Schema** | Response structure validity (keys, types, value ranges) | Every run |
+| **Agreement** | Behavior-level match rate vs. human labels (target: 85%+) | Every run |
+| **Consistency** | Self-agreement across repeated runs (measures model determinism) | Before model changes |
+| **Drift** | Activation rate shifts >15pp against a baseline | After model updates |
+| **Regression** | Side-by-side diff between two prompt versions | Before prompt bumps, cross-model validation |
+
+### CI Integration
+
+A dedicated GitHub Actions workflow (`eval.yml`) automatically runs schema + agreement checks on any PR that modifies prompt templates (`shared/prompts/**`). This catches scoring regressions before they reach production — no manual testing required.
+
+```bash
+# Run locally before a prompt change
+cd webapp
+uv run python ../shared/eval/run_eval.py --dry-run           # Preview what will run
+uv run python ../shared/eval/run_eval.py                      # Full schema + agreement check
+uv run python ../shared/eval/run_eval.py --check consistency  # Self-consistency analysis
+```
+
+Cost: ~$0.25 for a full 50-entry run, ~$0.15 for CI (33-entry subset). See [`shared/eval/README.md`](shared/eval/README.md) for full documentation.
+
 ## Security
 
 | Layer | Mechanism | Protects Against |
@@ -205,7 +250,7 @@ Everything runs locally. No data leaves your machine except the API calls to Ant
 | Input validation | Pydantic constraints, length limits, path checks | Oversized payloads, path traversal |
 | Rate limiting | 10 req/min sliding window (webapp) | API abuse |
 | CORS | Localhost-only default (webapp) | Unauthorized cross-origin access |
-| Automated testing | 769 tests including security-focused suites | Regressions |
+| Automated testing | 848 tests including security-focused suites | Regressions |
 | CI security review | Claude security review on PRs | New vulnerabilities |
 
 All user-controlled strings are escaped before rendering in HTML. Shell commands use argument arrays (`execFileSync`) instead of string interpolation. The webapp validates all inputs with Pydantic models and enforces rate limits. Security-focused test suites verify XSS and injection protections.
@@ -269,12 +314,16 @@ codefluent/
 ├── shared/                    # Shared resources (both interfaces)
 │   ├── benchmarks.json        # Population benchmark data
 │   ├── pricing.json           # Token pricing by model
-│   └── prompts/               # Versioned prompt templates
-│       ├── registry.json      # Active version pointers
-│       ├── scoring/v1.0.md        # Session scoring prompt
-│       ├── config/v1.0.md         # CLAUDE.md scoring prompt
-│       ├── optimizer/v1.1.md      # Prompt optimizer prompt (config-aware)
-│       └── single_scoring/v1.0.md # Single-prompt verification scorer
+│   ├── prompts/               # Versioned prompt templates
+│   │   ├── registry.json      # Active version pointers
+│   │   ├── scoring/v1.0.md        # Session scoring prompt
+│   │   ├── config/v1.0.md         # CLAUDE.md scoring prompt
+│   │   ├── optimizer/v1.1.md      # Prompt optimizer prompt (config-aware)
+│   │   └── single_scoring/v1.0.md # Single-prompt verification scorer
+│   └── eval/                  # Scoring regression testing
+│       ├── golden_set.json    # 50 curated test cases
+│       ├── run_eval.py        # CLI runner (schema, agreement, drift, regression checks)
+│       └── README.md          # Eval framework docs
 ├── docs/                      # Design docs and specs
 │   ├── PROJECT_PLAN.md
 │   ├── TECHNICAL_SPEC.md
@@ -311,23 +360,24 @@ See [`webapp/README.md`](webapp/README.md) for configuration, CORS, and Windows 
 
 ### Testing
 
-The project has **769 automated tests** across both interfaces:
+The project has **848 automated tests** across both interfaces:
 
 ```bash
 cd vscode-extension
 npm test                   # 528 tests across 14 suites (Jest)
 
 cd webapp
-uv run pytest tests/ -v    # 241 tests across 5 suites (pytest)
+uv run pytest tests/ -v    # 320 tests across 6 suites (pytest)
 ```
 
-Test suites cover scoring, parsing, caching, analytics, pricing, XSS prevention, shell injection, path traversal, rate limiting, CORS, and API surface. All tests must pass before merging to main.
+Test suites cover scoring, parsing, caching, analytics, pricing, XSS prevention, shell injection, path traversal, rate limiting, CORS, API surface, and scoring prompt regression testing. The eval framework (`shared/eval/`) validates scoring outputs against a [golden set of 50 curated entries](shared/eval/README.md). All tests must pass before merging to main.
 
 ### CI/CD
 
-Four GitHub Actions workflows run automatically:
+Five GitHub Actions workflows run automatically:
 
-- **CI** (`ci.yml`) — Runs on every PR: compiles TypeScript, runs all 769 tests, plus `npm audit` and `pip-audit` for dependency vulnerabilities. Must pass to merge.
+- **CI** (`ci.yml`) — Runs on every PR: compiles TypeScript, runs all 848 tests, plus `npm audit` and `pip-audit` for dependency vulnerabilities. Must pass to merge.
+- **Eval** (`eval.yml`) — Runs on PRs that modify `shared/prompts/**`: scores the golden set via the Anthropic API, validates schema + agreement against human-labeled ground truth. See [Eval Framework](#eval-framework) below.
 - **Claude Code Review** (`claude-review.yml`) — AI-powered PR review, responds to `@claude` mentions.
 - **Security Review** (`security-review.yml`) — Grep-based checks for security anti-patterns (inline onclick, string interpolation in shell commands, missing escapeHtml).
 - **Release** (`release.yml`) — Triggered by version tags (`v*`). Builds VSIX, publishes to VS Code Marketplace, uploads to GitHub Release.

--- a/shared/eval/README.md
+++ b/shared/eval/README.md
@@ -59,12 +59,25 @@ Acceptable tolerance: individual behaviors should match exactly; overall scores 
 
 ## Eval Runner
 
-Automated regression checker that scores the golden set against the Anthropic API and validates outputs.
+Automated regression checker that scores the golden set against the Anthropic API and validates outputs. Run from the `webapp/` directory using `uv`.
+
+### File Structure
+
+```
+shared/eval/
+├── golden_set.json    # 50 human-labeled test cases
+├── run_eval.py        # CLI entry point (argparse)
+├── scorer.py          # Prompt loading, template filling, API calls with retry
+├── checks.py          # 5 check implementations (schema, agreement, consistency, drift, regression)
+├── report.py          # JSON + stdout output formatting, cost tracking via pricing.json
+├── results/           # Output directory (gitignored)
+└── README.md          # This file
+```
 
 ### Quick Start
 
 ```bash
-# From project root — set your API key
+# Set your API key
 export ANTHROPIC_API_KEY=sk-ant-...
 
 # Dry run (no API calls)
@@ -84,11 +97,13 @@ cd webapp && uv run python ../shared/eval/run_eval.py --verbose
 
 | Check | What it does | API calls | Opt-in |
 |-------|-------------|-----------|--------|
-| `schema` | Validates response structure (keys, types) | Included in default run | Default |
-| `agreement` | Compares actual vs expected behaviors | Included in default run | Default |
-| `consistency` | Runs subset N times, measures self-agreement | N × subset_size | `--check consistency` |
-| `drift` | Compares activation rates against a baseline | 0 (uses saved results) | `--check drift --baseline PATH` |
-| `regression` | Diffs results between two prompt versions | 2 × section_size | `--check regression` |
+| `schema` | Validates response structure (keys, types, value ranges) | Included in default run | Default |
+| `agreement` | Compares actual vs expected behaviors per entry (target: 85%+) | Included in default run | Default |
+| `consistency` | Runs subset N times, measures self-agreement across runs | N × subset_size | `--check consistency` |
+| `drift` | Compares activation rates against a baseline, flags >15pp shifts | 0 (uses saved results) | `--check drift --baseline PATH` |
+| `regression` | Runs a section with two prompt versions, diffs behavior changes | 2 × section_size | `--check regression` |
+
+`--check all` (the default) runs schema + agreement in a single API pass. Consistency, drift, and regression are opt-in because they require additional API calls or a baseline file.
 
 ### CLI Options
 
@@ -108,16 +123,60 @@ cd webapp && uv run python ../shared/eval/run_eval.py --verbose
 --verbose               Print each API call
 ```
 
+### Example Output
+
+```
+Running golden set (all sections)
+  Scored 50 entries
+
+  SCHEMA
+  [PASS] 50/50 entries have valid schema
+
+  AGREEMENT
+  [PASS] Overall agreement: 88.5% (threshold: 85%)
+  By section:
+    single_scoring: 90.5%
+    session_scoring: 81.1%
+    config_scoring: 89.8%
+    optimizer: 94.5%
+  Behaviors below 85%:
+    - iteration_and_refinement: 78.0%
+    - clarifying_goals: 78.0%
+
+  Cost: 34,046 input + 9,762 output tokens
+  Estimated: $0.2486
+
+Results saved to: shared/eval/results/2026-03-19_183628_agreement_schema.json
+```
+
 ### Cost
 
 - Full golden set (50 entries): ~$0.20-0.30
-- Consistency (10 × 3 runs): ~$0.10
+- CI subset (33 entries): ~$0.10-0.15
+- Consistency (10 entries × 3 runs): ~$0.10
 - Regression (one section, 2 versions): ~$0.05-0.15
+
+### CI Integration
+
+A GitHub Actions workflow (`eval.yml`) automatically runs schema + agreement checks on PRs that modify `shared/prompts/**`. It uses the `single_scoring` + `config_scoring` subset (33 entries, ~$0.15/run) and requires the `ANTHROPIC_API_KEY` repo secret. Skipped for Dependabot PRs.
 
 ### Tests
 
+82 tests in `webapp/tests/test_eval.py`:
+
+| Category | Tests | What it covers |
+|----------|-------|----------------|
+| `scorer.py` | 18 | Prompt loading, template filling, golden set template integration |
+| `checks.py` | 19 | Schema validation, agreement computation, drift detection, regression diffing |
+| `report.py` | 11 | Cost computation, JSON output, stdout formatting |
+| `run_eval.py` | 15 | Argument parsing, dry-run, section filtering, check routing, error handling |
+| Integration | 16 | End-to-end pipeline with mocked API, golden set structure verification |
+| Live API | 3 | Real API calls against golden set entries (excluded by default) |
+
 ```bash
 cd webapp
-uv run pytest tests/test_eval.py -v              # Unit + mock integration tests
-uv run pytest tests/test_eval.py -m live          # Live API tests (~$0.02)
+uv run pytest tests/test_eval.py -v       # Unit + mock integration (79 tests)
+uv run pytest tests/test_eval.py -m live   # Live API tests only (~$0.02)
 ```
+
+Live tests are excluded by default (`addopts = "-m 'not live'"` in `pyproject.toml`). They require `ANTHROPIC_API_KEY` to be set.

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -131,12 +131,13 @@ CORS is restricted to localhost origins by default. The allowed origin is determ
 
 ## Testing
 
-The webapp has **241 tests** across 5 suites. Run with:
+The webapp has **320 tests** across 6 suites. Run with:
 
 ```bash
 cd webapp
 uv run pytest tests/ -v         # Run all tests
 uv run pytest tests/test_api.py  # Run a specific suite
+uv run pytest tests/test_eval.py -m live  # Run live API eval tests (~$0.02)
 ```
 
 | Suite | Tests | What it covers |
@@ -146,6 +147,9 @@ uv run pytest tests/test_api.py  # Run a specific suite
 | `test_security.py` | 38 | Rate limiting, CORS, error leakage, path traversal, security headers, XSS source-level verification |
 | `test_extract_prompts.py` | 58 | JSONL parsing, content extraction, session filtering, metadata extraction |
 | `test_prompts.py` | 17 | Prompt loading, template filling, registry consistency |
+| `test_eval.py` | 79 | Eval framework: scorer, checks, report, CLI args, golden set integration (+ 3 live API tests) |
+
+Live API tests (`@pytest.mark.live`) are excluded by default and require `ANTHROPIC_API_KEY`. Run with `-m live` to include them.
 
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full PR checklist and test requirements.
 


### PR DESCRIPTION
## Summary

- Adds eval framework (`shared/eval/`) and eval CI workflow (`eval.yml`) to project structure in both `CLAUDE.md` and `README.md`
- Adds prominent **Eval Framework** section to `README.md` covering golden set, automated checks, CI integration, and cross-model validation
- Updates test counts: 848 total (528 Jest + 320 pytest)
- Adds eval runner commands to `CLAUDE.md` Key Commands section
- Updates `webapp/README.md` test count (320 tests, 6 suites) and test table
- Updates memory file with current test counts

Closes #121

## Test plan

- [x] `CLAUDE.md` project structure includes `shared/eval/` files
- [x] `CLAUDE.md` key commands includes eval runner usage
- [x] `CLAUDE.md` testing section reflects updated test count (320 tests, 6 suites)
- [x] `README.md` project structure includes `shared/eval/`
- [x] `README.md` has prominent Eval Framework section
- [x] `README.md` testing section updated (848 total)
- [x] `webapp/README.md` test count and table updated (320 tests, 6 suites)
- [x] Memory file test count updated
- [x] All 848 tests pass (528 + 320)

🤖 Generated with [Claude Code](https://claude.com/claude-code)