### PR TITLE
fix: conversation table formatting lacks cell padding/spacing

### DIFF
--- a/webapp/static/app.js
+++ b/webapp/static/app.js
@@ -905,6 +905,7 @@ function renderConversationTokenTable() {
   }
 
   let html = `
+    <h3>Conversation Token Details</h3>
     <div class="conversation-table-wrapper">
       <table class="conversation-token-table">
         <thead>

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -958,10 +958,12 @@ h3 { font-size: 16px; font-weight: 600; margin-bottom: 12px; }
   color: var(--accent);
 }
 .conversation-token-table td {
-  padding: 8px 12px;
+  padding: 10px 12px;
   border-bottom: 1px solid var(--border);
   color: var(--text-primary);
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  text-align: left;
 }
 .conversation-token-table tbody tr:hover {
   background: var(--bg-hover);


### PR DESCRIPTION
## Summary
- Added `white-space: nowrap` and matched padding (`10px 12px`) on `.conversation-token-table td` to prevent column compression in the webapp Usage tab table
- Added "Conversation Token Details" heading above the table, matching the VS Code extension

Closes #137

## Test plan
- [x] Webapp Usage tab table has proper cell spacing — columns no longer run together
- [x] Horizontal scrollbar appears for overflow columns (Cache R/C, Out/In, Score)
- [x] "Conversation Token Details" heading renders above the table
- [x] VS Code extension table unchanged (already had proper formatting)
- [x] All webapp tests pass (449 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)