### PR TITLE
fix: prompt counts inflated by tool_result messages

### DIFF
--- a/vscode-extension/media/app.js
+++ b/vscode-extension/media/app.js
@@ -1228,7 +1228,7 @@ function renderConversationEfficiencyCards(analytics) {
   // Find most efficient conversation (lowest tokens_per_prompt among conversations with prompts)
   let mostEfficient = null
   for (const s of conversations) {
-    if (s.user_message_count > 0 && s.total_tokens > 0) {
+    if ((s.prompt_count || s.user_message_count) > 0 && s.total_tokens > 0) {
       if (!mostEfficient || s.tokens_per_prompt < mostEfficient.tokens_per_prompt) {
         mostEfficient = s
       }
@@ -1246,7 +1246,7 @@ function renderConversationEfficiencyCards(analytics) {
 
   const totalCost = agg.total_estimated_cost != null ? agg.total_estimated_cost : conversations.reduce((s, sess) => s + (sess.estimated_cost || 0), 0)
 
-  const totalPrompts = conversations.reduce((s, sess) => s + sess.user_message_count, 0)
+  const totalPrompts = conversations.reduce((s, sess) => s + (sess.prompt_count || sess.user_message_count), 0)
 
   // Compute avg cache read/creation ratio and output/input ratio
   const totalCacheRead = conversations.reduce((sum, s) => sum + (s.total_cache_read_tokens || 0), 0)
@@ -1334,7 +1334,7 @@ function renderConversationTokenTable(conversations) {
         vb = (b.project || '').toLowerCase()
         return va < vb ? -dir : va > vb ? dir : 0
       case 'prompts':
-        return (a.user_message_count - b.user_message_count) * dir
+        return ((a.prompt_count || a.user_message_count) - (b.prompt_count || b.user_message_count)) * dir
       case 'total_tokens':
         return (a.total_tokens - b.total_tokens) * dir
       case 'estimated_cost':
@@ -1342,8 +1342,8 @@ function renderConversationTokenTable(conversations) {
       case 'tokens_per_prompt':
         return (a.tokens_per_prompt - b.tokens_per_prompt) * dir
       case 'cost_per_prompt':
-        va = a.user_message_count > 0 && a.estimated_cost > 0 ? a.estimated_cost / a.user_message_count : 0
-        vb = b.user_message_count > 0 && b.estimated_cost > 0 ? b.estimated_cost / b.user_message_count : 0
+        va = (a.prompt_count || a.user_message_count) > 0 && a.estimated_cost > 0 ? a.estimated_cost / (a.prompt_count || a.user_message_count) : 0
+        vb = (b.prompt_count || b.user_message_count) > 0 && b.estimated_cost > 0 ? b.estimated_cost / (b.prompt_count || b.user_message_count) : 0
         return (va - vb) * dir
       case 'cache_hit_rate':
         return (a.cache_hit_rate - b.cache_hit_rate) * dir
@@ -1369,11 +1369,12 @@ function renderConversationTokenTable(conversations) {
   const rows = visible.map(s => {
     const date = s.started_at ? new Date(s.started_at).toLocaleDateString() : '-'
     const project = s.project || '-'
-    const prompts = s.user_message_count || 0
+    const pc = s.prompt_count || s.user_message_count || 0
+    const prompts = pc
     const totalTokens = formatTokens(s.total_tokens || 0)
     const cost = s.estimated_cost > 0 ? formatCost(s.estimated_cost) : '-'
-    const tokensPerPrompt = s.user_message_count > 0 ? formatTokens(Math.round(s.tokens_per_prompt)) : '-'
-    const costPerPrompt = s.user_message_count > 0 && s.estimated_cost > 0 ? formatCost(s.estimated_cost / s.user_message_count) : '-'
+    const tokensPerPrompt = pc > 0 ? formatTokens(Math.round(s.tokens_per_prompt)) : '-'
+    const costPerPrompt = pc > 0 && s.estimated_cost > 0 ? formatCost(s.estimated_cost / pc) : '-'
     const cacheHit = Math.round((s.cache_hit_rate || 0) * 100) + '%'
     const cacheRC = s.total_cache_creation_tokens > 0
       ? (s.total_cache_read_tokens / s.total_cache_creation_tokens).toFixed(1) + 'x' : '-'
@@ -1454,7 +1455,7 @@ function renderScoreCorrelation(conversations) {
 
   // --- Compute derived features for all conversations ---
   const enriched = allConversations.map(s => {
-    const promptCount = s.user_message_count || 1
+    const promptCount = s.prompt_count || s.user_message_count || 1
     const costPerPrompt = s.estimated_cost / promptCount
     const cacheReadCreation = s.total_cache_creation_tokens > 0
       ? s.total_cache_read_tokens / s.total_cache_creation_tokens : null

--- a/vscode-extension/src/analytics.ts
+++ b/vscode-extension/src/analytics.ts
@@ -3,6 +3,11 @@ import { ParsedConversation } from './conversation'
 import { ScoreResult, getISOWeekKey, BEHAVIORS } from './scoring'
 import { estimateSessionCost, loadPricing, PricingData } from './pricing'
 
+/** Get the actual prompt count (messages with content), falling back to user_message_count for legacy ParsedSession */
+function getPromptCount(c: ParsedConversation | ParsedSession): number {
+  return 'prompt_count' in c ? (c as ParsedConversation).prompt_count : c.user_message_count
+}
+
 export interface WeeklyTokenAggregation {
   week: string
   total_tokens: number
@@ -114,14 +119,14 @@ export function computeConversationEfficiency(conversations: (ParsedConversation
   }
 
   const totalTokens = conversations.reduce((sum, c) => sum + c.total_tokens, 0)
-  const totalPrompts = conversations.reduce((sum, c) => sum + c.user_message_count, 0)
+  const totalPrompts = conversations.reduce((sum, c) => sum + getPromptCount(c), 0)
   const avgTokensPerPrompt = totalPrompts > 0 ? totalTokens / totalPrompts : 0
   const avgCacheHitRate = conversations.reduce((sum, c) => sum + c.cache_hit_rate, 0) / conversations.length
 
   // Most efficient = lowest tokens_per_prompt among conversations that have prompts
   let mostEfficient: { id: string; tokens_per_prompt: number } | null = null
   for (const c of conversations) {
-    if (c.user_message_count > 0 && c.total_tokens > 0) {
+    if (getPromptCount(c) > 0 && c.total_tokens > 0) {
       if (!mostEfficient || c.tokens_per_prompt < mostEfficient.tokens_per_prompt) {
         mostEfficient = { id: c.id, tokens_per_prompt: Math.round(c.tokens_per_prompt) }
       }

--- a/vscode-extension/src/conversation.ts
+++ b/vscode-extension/src/conversation.ts
@@ -11,6 +11,7 @@ export interface ParsedConversation {
   started_at: string | null
   ended_at: string | null
   user_prompts: string[]
+  prompt_count: number
   user_message_count: number
   assistant_message_count: number
   tool_use_count: number
@@ -132,7 +133,8 @@ export function buildConversations(
 
     timestamps.sort()
     const totalTokens = totalInputTokens + totalOutputTokens + totalCacheCreationTokens + totalCacheReadTokens
-    const tokensPerPrompt = userMsgCount > 0 ? totalTokens / userMsgCount : 0
+    const promptCount = userPrompts.length
+    const tokensPerPrompt = promptCount > 0 ? totalTokens / promptCount : 0
     const cacheHitDenom = totalCacheReadTokens + totalInputTokens + totalCacheCreationTokens
     const cacheHitRate = cacheHitDenom > 0 ? totalCacheReadTokens / cacheHitDenom : 0
 
@@ -144,6 +146,7 @@ export function buildConversations(
       started_at: timestamps[0] || null,
       ended_at: timestamps[timestamps.length - 1] || null,
       user_prompts: userPrompts,
+      prompt_count: promptCount,
       user_message_count: userMsgCount,
       assistant_message_count: assistantMsgCount,
       tool_use_count: toolUseCount,

--- a/vscode-extension/test/unit/conversation.test.ts
+++ b/vscode-extension/test/unit/conversation.test.ts
@@ -504,6 +504,36 @@ describe('buildConversations', () => {
     ]
     const result = buildConversations(messages, 'proj', 'enc', 60)
     expect(result[0].tokens_per_prompt).toBe(200) // 400 / 2
+    expect(result[0].prompt_count).toBe(2) // both have content
+  })
+
+  it('distinguishes prompt_count from user_message_count', () => {
+    // Simulate tool_result messages: type 'user' but no content
+    const messages = [
+      makeUserMessage('2026-03-01T10:00:00.000Z', 'Real prompt', 'sess-1', 0),
+      makeAssistantMessage('2026-03-01T10:00:05.000Z', {
+        input_tokens: 50, output_tokens: 50,
+        cache_creation_input_tokens: 0, cache_read_input_tokens: 0,
+      }, 'sess-1', 1),
+      // Tool result messages — type 'user' with no content
+      { type: 'user', timestamp: '2026-03-01T10:00:10.000Z', session_id: 'sess-1', file_position: 2, used_plan_mode: false } as TimestampedMessage,
+      { type: 'user', timestamp: '2026-03-01T10:00:15.000Z', session_id: 'sess-1', file_position: 3, used_plan_mode: false } as TimestampedMessage,
+      { type: 'user', timestamp: '2026-03-01T10:00:20.000Z', session_id: 'sess-1', file_position: 4, used_plan_mode: false } as TimestampedMessage,
+      makeAssistantMessage('2026-03-01T10:00:25.000Z', {
+        input_tokens: 50, output_tokens: 50,
+        cache_creation_input_tokens: 0, cache_read_input_tokens: 0,
+      }, 'sess-1', 5),
+      makeUserMessage('2026-03-01T10:05:00.000Z', 'Another real prompt', 'sess-1', 6),
+      makeAssistantMessage('2026-03-01T10:05:05.000Z', {
+        input_tokens: 50, output_tokens: 50,
+        cache_creation_input_tokens: 0, cache_read_input_tokens: 0,
+      }, 'sess-1', 7),
+    ]
+    const result = buildConversations(messages, 'proj', 'enc', 60)
+    expect(result).toHaveLength(1)
+    expect(result[0].user_message_count).toBe(5) // all type 'user' messages
+    expect(result[0].prompt_count).toBe(2) // only messages with content
+    expect(result[0].tokens_per_prompt).toBe(150) // 300 total / 2 prompts (not / 5)
   })
 
   it('computes cache_hit_rate correctly', () => {

--- a/webapp/conversations.py
+++ b/webapp/conversations.py
@@ -112,7 +112,8 @@ def build_conversations(
 
         timestamps.sort()
         total_tokens = total_input_tokens + total_output_tokens + total_cache_creation_tokens + total_cache_read_tokens
-        tokens_per_prompt = total_tokens / user_msg_count if user_msg_count > 0 else 0
+        prompt_count = len(user_prompts)
+        tokens_per_prompt = total_tokens / prompt_count if prompt_count > 0 else 0
         cache_hit_denom = total_cache_read_tokens + total_input_tokens + total_cache_creation_tokens
         cache_hit_rate = total_cache_read_tokens / cache_hit_denom if cache_hit_denom > 0 else 0
 
@@ -124,6 +125,7 @@ def build_conversations(
             "started_at": timestamps[0] if timestamps else None,
             "ended_at": timestamps[-1] if timestamps else None,
             "user_prompts": user_prompts,
+            "prompt_count": prompt_count,
             "user_message_count": user_msg_count,
             "assistant_message_count": assistant_msg_count,
             "tool_use_count": tool_use_count,

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -494,7 +494,7 @@ async def get_conversation_analytics(
                 "project": s.get("project", ""),
                 "started_at": s.get("started_at"),
                 "model": s.get("model"),
-                "prompt_count": len(s.get("user_prompts", [])),
+                "prompt_count": s.get("prompt_count", len(s.get("user_prompts", []))),
                 "total_tokens": s.get("total_tokens", 0),
                 "total_input_tokens": s.get("total_input_tokens", 0),
                 "total_output_tokens": s.get("total_output_tokens", 0),

--- a/webapp/tests/test_conversations.py
+++ b/webapp/tests/test_conversations.py
@@ -429,6 +429,35 @@ class TestBuildConversations:
         ]
         result = build_conversations(messages, "proj", "enc", 60)
         assert result[0]["tokens_per_prompt"] == 200
+        assert result[0]["prompt_count"] == 2
+
+    def test_prompt_count_excludes_contentless_user_messages(self):
+        """Tool result messages are type 'user' but have no content — they should not count as prompts."""
+        messages = [
+            _make_user_message("2026-03-01T10:00:00.000Z", "Real prompt", pos=0),
+            _make_assistant_message("2026-03-01T10:00:05.000Z", usage={
+                "input_tokens": 50, "output_tokens": 50,
+                "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+            }, pos=1),
+            # Tool result messages — type 'user' with no content
+            {"type": "user", "timestamp": "2026-03-01T10:00:10.000Z", "session_id": "sess-1", "file_position": 2, "used_plan_mode": False},
+            {"type": "user", "timestamp": "2026-03-01T10:00:15.000Z", "session_id": "sess-1", "file_position": 3, "used_plan_mode": False},
+            {"type": "user", "timestamp": "2026-03-01T10:00:20.000Z", "session_id": "sess-1", "file_position": 4, "used_plan_mode": False},
+            _make_assistant_message("2026-03-01T10:00:25.000Z", usage={
+                "input_tokens": 50, "output_tokens": 50,
+                "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+            }, pos=5),
+            _make_user_message("2026-03-01T10:05:00.000Z", "Another real prompt", pos=6),
+            _make_assistant_message("2026-03-01T10:05:05.000Z", usage={
+                "input_tokens": 50, "output_tokens": 50,
+                "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+            }, pos=7),
+        ]
+        result = build_conversations(messages, "proj", "enc", 60)
+        assert len(result) == 1
+        assert result[0]["user_message_count"] == 5  # all type 'user' messages
+        assert result[0]["prompt_count"] == 2  # only messages with content
+        assert result[0]["tokens_per_prompt"] == 150  # 300 total / 2 prompts
 
     def test_cache_hit_rate(self):
         messages = [


### PR DESCRIPTION
## Summary
- Claude Code's JSONL format sends tool results as `type: "user"` messages — in real data, ~95% of "user" messages are tool_result, not actual prompts
- VS Code extension displayed `user_message_count` (all user-type messages) while webapp displayed `len(user_prompts)` (only messages with content), causing a ~20x discrepancy
- Added `prompt_count` field to `ParsedConversation` in both TS and Python conversation builders, counting only user messages with actual text content
- `tokens_per_prompt` now divides by `prompt_count` instead of `user_message_count`, giving accurate per-prompt metrics
- Both interfaces now display consistent, correct prompt counts

Closes #139

## Test plan
- [x] All 616 TS tests pass (1 new test for prompt_count vs user_message_count)
- [x] All 450 Python tests pass (1 new test for same)
- [x] New tests verify: 5 user messages with only 2 having content → prompt_count=2, user_message_count=5, tokens_per_prompt divides by 2
- [x] Rebuild VSIX and verify table shows correct prompt counts
- [x] Verify webapp Usage tab shows correct counts and tokens/prompt values

🤖 Generated with [Claude Code](https://claude.com/claude-code)