### PR TITLE
fix: Run Analysis scores stale conversation data instead of latest sessions (#151)

### DIFF
--- a/vscode-extension/media/app.js
+++ b/vscode-extension/media/app.js
@@ -693,9 +693,27 @@ document.getElementById('run-scoring-btn').addEventListener('click', () => {
 })
 
 async function runScoring(scopeValue) {
+  const btn = document.getElementById('run-scoring-btn')
+  btn.disabled = true
+  btn.textContent = 'Loading sessions...'
+
+  // Always fetch fresh conversations before scoring
+  try {
+    state.conversations = await postMessageRequest('getConversations')
+    updateTimeScopeCounts()
+  } catch (e) {
+    document.getElementById('fluency-results').innerHTML =
+      '<p class="empty-state">Failed to load conversations. Please try again.</p>'
+    btn.disabled = false
+    btn.textContent = 'Run Analysis'
+    return
+  }
+
   if (!state.conversations?.conversations?.length) {
     document.getElementById('fluency-results').innerHTML =
-      '<p class="empty-state">Conversations still loading — please wait a moment and try again.</p>'
+      '<p class="empty-state">No conversations found. Check your session data path.</p>'
+    btn.disabled = false
+    btn.textContent = 'Run Analysis'
     return
   }
 
@@ -703,6 +721,8 @@ async function runScoring(scopeValue) {
   if (ids.length === 0) {
     document.getElementById('fluency-results').innerHTML =
       '<p class="empty-state">No conversations found in the selected time range.</p>'
+    btn.disabled = false
+    btn.textContent = 'Run Analysis'
     return
   }
 
@@ -713,8 +733,6 @@ async function runScoring(scopeValue) {
   s.conversationScope = scopeValue
   vscode.setState(s)
 
-  const btn = document.getElementById('run-scoring-btn')
-  btn.disabled = true
   btn.textContent = 'Analyzing...'
   showLoader('fluency-results')
 

--- a/vscode-extension/src/webviewProvider.ts
+++ b/vscode-extension/src/webviewProvider.ts
@@ -259,8 +259,10 @@ export class CodeFluentViewProvider implements vscode.WebviewViewProvider {
 
     const client = new Anthropic({ apiKey })
     const cached = this.cache.read()
-    const convData = this.dataCache.getConversations().data || getAllConversations(undefined, undefined, this.getSessionDataPath(), 200)
-    const conversations = convData.conversations || convData.sessions || []
+    // Always fetch fresh conversations when user explicitly runs scoring
+    const convData = getAllConversations(undefined, undefined, this.getSessionDataPath(), 200)
+    this.dataCache.setConversations(convData)
+    const conversations = convData.conversations || []
     const allConversations = Object.fromEntries(conversations.map((c: any) => [c.id, c]))
 
     const { results, stats } = await scoreConversations(conversationIds, allConversations, cached, client, force)
@@ -408,8 +410,10 @@ export class CodeFluentViewProvider implements vscode.WebviewViewProvider {
 
   private async handleGetConversationAnalytics(payload?: { project?: string }) {
     const project = payload?.project ?? this.getWorkspaceProjectName()
-    const convData = this.dataCache.getConversations().data || getAllConversations(undefined, undefined, this.getSessionDataPath(), 200)
-    let conversations = convData.conversations || convData.sessions || []
+    // Always fetch fresh conversations for analytics
+    const convData = getAllConversations(undefined, undefined, this.getSessionDataPath(), 200)
+    this.dataCache.setConversations(convData)
+    let conversations = convData.conversations || []
     if (project) {
       conversations = conversations.filter((c: any) => c.project === project)
     }

--- a/vscode-extension/test/integration/webviewProvider.test.ts
+++ b/vscode-extension/test/integration/webviewProvider.test.ts
@@ -952,13 +952,20 @@ describe('CodeFluentViewProvider', () => {
       expect(getAllConversations).toHaveBeenCalledTimes(1)
     })
 
-    it('runScoring uses session cache instead of re-parsing', async () => {
+    it('runScoring always fetches fresh conversations instead of using cache', async () => {
       process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key'
-      const mockSessions = {
+      const staleConversations = {
         conversations: [{ id: 's1', user_prompts: ['hi'], used_plan_mode: false, thinking_count: 0, tools_used: [] }],
         metadata: { total_sessions: 1, total_projects: 1, total_prompts: 1, extracted_at: '' },
       }
-      ;(getAllConversations as jest.Mock).mockReturnValue(mockSessions)
+      const freshConversations = {
+        conversations: [
+          { id: 's1', user_prompts: ['hi'], used_plan_mode: false, thinking_count: 0, tools_used: [] },
+          { id: 's2', user_prompts: ['new session'], used_plan_mode: false, thinking_count: 0, tools_used: [] },
+        ],
+        metadata: { total_sessions: 2, total_projects: 1, total_prompts: 2, extracted_at: '' },
+      }
+      ;(getAllConversations as jest.Mock).mockReturnValue(staleConversations)
       ;(scoreConversations as jest.Mock).mockResolvedValue({ results: {}, stats: { scored: 0, cached: 0, skipped_no_prompts: 0, errored: 0 } })
       ;(computeAggregate as jest.Mock).mockReturnValue({})
 
@@ -966,15 +973,27 @@ describe('CodeFluentViewProvider', () => {
       await sendMessage({ type: 'getSessions', requestId: 'req-cache-6' })
       ;(getAllConversations as jest.Mock).mockClear()
 
-      // Now run scoring — should use cached sessions
+      // Update mock to return fresh data (simulates new JSONL files on disk)
+      ;(getAllConversations as jest.Mock).mockReturnValue(freshConversations)
+
+      // Now run scoring — should fetch fresh, not use cache
       await sendMessage({
         type: 'runScoring',
         requestId: 'req-cache-7',
-        payload: { session_ids: ['s1'] },
+        payload: { session_ids: ['s1', 's2'] },
       })
 
-      // getAllSessions should NOT have been called again
-      expect(getAllConversations).not.toHaveBeenCalled()
+      // getAllConversations SHOULD have been called to get fresh data
+      expect(getAllConversations).toHaveBeenCalledTimes(1)
+
+      // scoreConversations should see both conversations (including the new one)
+      expect(scoreConversations).toHaveBeenCalledWith(
+        ['s1', 's2'],
+        expect.objectContaining({ s2: expect.objectContaining({ id: 's2' }) }),
+        expect.any(Object),
+        expect.any(Object),
+        false,
+      )
 
       delete process.env.ANTHROPIC_API_KEY
     })
@@ -1513,6 +1532,46 @@ describe('CodeFluentViewProvider', () => {
       )
 
       ;(vscode.workspace as any).workspaceFolders = undefined
+    })
+
+    it('always fetches fresh conversations instead of using cache', async () => {
+      const staleConversations = {
+        conversations: [
+          { id: 's1', project: 'proj', user_prompts: ['hi'], total_tokens: 1000 },
+        ],
+        metadata: { total_sessions: 1, total_projects: 1, total_prompts: 1, extracted_at: '' },
+      }
+      const freshConversations = {
+        conversations: [
+          { id: 's1', project: 'proj', user_prompts: ['hi'], total_tokens: 1000 },
+          { id: 's2', project: 'proj', user_prompts: ['new'], total_tokens: 2000 },
+        ],
+        metadata: { total_sessions: 2, total_projects: 1, total_prompts: 2, extracted_at: '' },
+      }
+      ;(getAllConversations as jest.Mock).mockReturnValue(staleConversations)
+      ;(buildConversationAnalytics as jest.Mock).mockReturnValue({
+        conversations: [], sessions: [], aggregates: {}, weekly: [],
+      })
+
+      // Prime the cache
+      await sendMessage({ type: 'getSessionAnalytics', requestId: 'req-analytics-fresh-1' })
+      ;(getAllConversations as jest.Mock).mockClear()
+
+      // Update mock to return fresh data
+      ;(getAllConversations as jest.Mock).mockReturnValue(freshConversations)
+
+      // Analytics should fetch fresh, not use cache
+      await sendMessage({ type: 'getSessionAnalytics', requestId: 'req-analytics-fresh-2' })
+
+      expect(getAllConversations).toHaveBeenCalledTimes(1)
+      expect(buildConversationAnalytics).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 's1' }),
+          expect.objectContaining({ id: 's2' }),
+        ]),
+        expect.any(Array),
+        undefined,
+      )
     })
   })
 })

--- a/webapp/static/app.js
+++ b/webapp/static/app.js
@@ -1200,25 +1200,52 @@ document.getElementById('run-scoring-btn').addEventListener('click', () => {
 })
 
 async function runScoring(scopeValue) {
-  if (!state.conversations?.conversations?.length) return
+  const btn = document.getElementById('run-scoring-btn')
+  btn.disabled = true
+  btn.textContent = 'Loading sessions...'
+
+  // Always fetch fresh conversations before scoring
+  try {
+    const freshConversations = await fetch(buildConversationsUrl()).then(r => r.json())
+    state.conversations = freshConversations
+    updateTimeScopeCounts()
+  } catch (e) {
+    document.getElementById('fluency-results').innerHTML =
+      '<p class="empty-state">Failed to load conversations. Please try again.</p>'
+    btn.disabled = false
+    btn.textContent = 'Run Analysis'
+    return
+  }
+
+  if (!state.conversations?.conversations?.length) {
+    document.getElementById('fluency-results').innerHTML =
+      '<p class="empty-state">No conversations found. Check your data path setting.</p>'
+    btn.disabled = false
+    btn.textContent = 'Run Analysis'
+    return
+  }
 
   const { ids, description } = resolveConversationIds(scopeValue, getFilteredConversations())
   if (ids.length === 0) {
     document.getElementById('fluency-results').innerHTML =
       '<p class="empty-state">No conversations found in the selected time range.</p>'
+    btn.disabled = false
+    btn.textContent = 'Run Analysis'
     return
   }
 
   const forceRescore = document.getElementById('force-rescore').checked
   if (forceRescore && ids.length > 20) {
-    if (!confirm(`Force Rescore will re-score all ${ids.length} conversations using the Anthropic API. Continue?`)) return
+    if (!confirm(`Force Rescore will re-score all ${ids.length} conversations using the Anthropic API. Continue?`)) {
+      btn.disabled = false
+      btn.textContent = 'Run Analysis'
+      return
+    }
   }
 
   // Persist selection
   localStorage.setItem('codefluent-conversation-scope', scopeValue)
 
-  const btn = document.getElementById('run-scoring-btn')
-  btn.disabled = true
   btn.textContent = 'Analyzing...'
   showLoader('fluency-results')
 


### PR DESCRIPTION
## Summary

- **Extension backend**: `handleRunScoring()` and `handleGetConversationAnalytics()` now call `getAllConversations()` fresh instead of reading from `dataCache`; cache is updated afterward for subsequent passive reads
- **Extension frontend**: `runScoring()` fetches fresh conversations via IPC before resolving IDs; shows "Loading sessions..." during fetch
- **Webapp frontend**: `runScoring()` fetches from `/api/conversations` before scoring; same UX pattern
- **Tests**: Updated stale cache test to assert fresh fetch behavior; added analytics freshness test (618 total, +1)

Closes #151

## Test plan

- [x] `npm test` passes (618 tests, 16 suites)
- [x] `uv run pytest` passes (450 tests, 9 suites)
- [x] E2E smoke test (webapp): Run Analysis picks up latest sessions (3/25 conversations appeared after fix, previously stuck at 3/21)
- [x] E2E smoke test (webapp): Usage tab conversation analytics show fresh data
- [x] E2E smoke test (webapp): Tab navigation and other features unaffected
- [x] E2E smoke test (VS Code extension): Run Analysis picks up latest sessions after new Claude Code activity
- [x] Verify "Loading sessions..." indicator appears before "Analyzing..." (VS Code extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)