### PR TITLE
fix: chain release build into release-please workflow (#156)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,8 +13,88 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  build-release:
+    name: Build & Release
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: vscode-extension/package-lock.json
+
+      - name: Install dependencies
+        working-directory: vscode-extension
+        run: npm ci
+
+      - name: Compile TypeScript
+        working-directory: vscode-extension
+        run: npm run compile
+
+      - name: Run tests
+        working-directory: vscode-extension
+        run: npm test
+
+      - name: Verify version matches tag
+        working-directory: vscode-extension
+        env:
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "Tag: $TAG, package.json version: $PKG_VERSION"
+          if [ "v$PKG_VERSION" != "$TAG" ]; then
+            echo "ERROR: package.json version ($PKG_VERSION) does not match tag ($TAG)"
+            exit 1
+          fi
+
+      - name: Package VSIX
+        working-directory: vscode-extension
+        run: npx @vscode/vsce package --allow-missing-repository
+
+      - name: Verify VSIX size
+        working-directory: vscode-extension
+        run: |
+          VSIX=$(ls *.vsix)
+          SIZE=$(stat --format=%s "$VSIX")
+          echo "VSIX: $VSIX ($SIZE bytes)"
+          if [ "$SIZE" -lt 500000 ]; then
+            echo "ERROR: VSIX is too small (<500KB) — node_modules likely excluded"
+            exit 1
+          fi
+          echo "vsix_path=vscode-extension/$VSIX" >> "$GITHUB_ENV"
+          echo "vsix_name=$VSIX" >> "$GITHUB_ENV"
+
+      - name: Publish to VS Code Marketplace
+        working-directory: vscode-extension
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npx @vscode/vsce publish --pat "$VSCE_PAT"
+
+      - name: Upload VSIX to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          gh release upload "$TAG" "${{ env.vsix_path }}#${{ env.vsix_name }}" --clobber
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          gh release edit "$TAG" --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,15 @@
-name: Release
+name: Release (Manual)
 
+# Manual fallback only — the normal release flow is handled by release-please.yml.
+# Use this if Release Please's chained build-release job fails and you need to retry,
+# or for manual tag releases outside the Release Please flow.
 on:
-  push:
-    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., v1.0.2)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -14,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
 
       - uses: actions/setup-node@v6
         with:
@@ -36,7 +45,7 @@ jobs:
       - name: Verify version matches tag
         working-directory: vscode-extension
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ inputs.tag }}
         run: |
           PKG_VERSION=$(node -p "require('./package.json').version")
           echo "Tag: $TAG, package.json version: $PKG_VERSION"
@@ -71,12 +80,17 @@ jobs:
       - name: Upload VSIX to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ inputs.tag }}
         run: |
-          # Release Please creates the GitHub Release; upload VSIX as asset
-          # Falls back to creating a new release if one doesn't exist (manual tag)
           gh release upload "$TAG" "${{ env.vsix_path }}#${{ env.vsix_name }}" --clobber 2>/dev/null || \
           gh release create "$TAG" \
             --generate-notes \
             --title "$TAG" \
             "${{ env.vsix_path }}#${{ env.vsix_name }}"
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          gh release edit "$TAG" --draft=false 2>/dev/null || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,8 +278,8 @@ chore: bump @anthropic-ai/sdk to 0.52.0
 - **`eval.yml`** — Runs on PRs touching `shared/prompts/**`: scores golden set (33 entries) via Anthropic API, validates schema + agreement (~$0.15/run). Skipped for Dependabot.
 - **`security-review.yml`** — Runs on every PR: grep-based checks for security anti-patterns (inline onclick, string interpolation in shell commands, missing escapeHtml)
 - **`claude-review.yml`** — AI code review via `claude-code-action@v1`. Triggered by `needs-review` label on PR (not on every push, to control API costs). Also responds to `@claude` mentions in PR comments.
-- **`release.yml`** — Triggered by version tags: builds VSIX, publishes to Marketplace, uploads to GitHub Release
-- **`release-please.yml`** — Auto-creates release PRs with changelog + version bumps from conventional commits
+- **`release-please.yml`** — Auto-creates release PRs with changelog + version bumps from conventional commits. When a release is created, chains into a `build-release` job that builds VSIX, publishes to Marketplace, uploads to GitHub Release, and marks the release as non-draft.
+- **`release.yml`** — Manual fallback (`workflow_dispatch` only) for retrying failed releases or manual tag releases. Not triggered automatically.
 
 ## Production Standards
 - **All new features must have tests.** No merging without test coverage for the change.


### PR DESCRIPTION
## Summary

- Chain the release build (VSIX packaging, Marketplace publish, GitHub Release upload) directly into `release-please.yml` as a second job conditioned on `releases_created == true`
- Add `gh release edit --draft=false` to publish the GitHub Release after VSIX upload
- Convert `release.yml` to manual-only fallback (`workflow_dispatch`) for retrying failed releases

This eliminates the `GITHUB_TOKEN` anti-cascade problem — no separate tag-triggered workflow needed.

## What changed

- **`release-please.yml`**: Added `build-release` job that runs when Release Please creates a release. Outputs `tag_name` from release-please step for downstream use.
- **`release.yml`**: Removed `push: tags: ['v*']` trigger. Now `workflow_dispatch` only with a `tag` input parameter. Serves as manual safety net.
- **`CLAUDE.md`**: Updated CI workflow docs to reflect new flow.

## Test plan

- [x] CI passes (tests + security — no release steps run on PRs)
- [x] Verify `release-please.yml` YAML is valid (jobs, outputs, conditionals) — validated via js-yaml parser
- [x] Release Please action v4 output names confirmed correct (`releases_created`, `tag_name`)
- [ ] ~Next actual release (merge release PR) should automatically build + publish without manual tag re-push~ — cannot test without a real release; manual fallback (`release.yml` workflow_dispatch) available if chained job fails
- [ ] ~GitHub Release should be marked as non-draft automatically~ — cannot test without a real release; `gh release edit --draft=false` step added, will verify on next release

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)