### PR TITLE
feat: add agent metrics display cards with sparklines (#167)

### DIFF
--- a/vscode-extension/media/app.js
+++ b/vscode-extension/media/app.js
@@ -1693,12 +1693,17 @@ function formatDuration(minutes) {
 async function loadConversationsExplorer() {
   document.getElementById('conversations-loading').style.display = ''
   document.getElementById('conversations-summary-cards').style.display = 'none'
+  document.getElementById('agent-metrics-section').style.display = 'none'
   document.getElementById('conversations-charts-row').style.display = 'none'
   document.getElementById('conversations-table-container').style.display = 'none'
   document.getElementById('conversations-empty').style.display = 'none'
   try {
     state.conversationsExplorer = await postMessageRequest('getConversationAnalytics', {})
     renderConversationsExplorer()
+    try {
+      const agentData = await postMessageRequest('getAgentMetrics', {})
+      renderAgentMetrics(agentData)
+    } catch (_e) { /* agent metrics are supplementary */ }
   } catch (e) {
     document.getElementById('conversations-loading').style.display = 'none'
     document.getElementById('conversations-empty').style.display = ''
@@ -1718,6 +1723,64 @@ function renderConversationsExplorer() {
   renderConversationsSummaryCards(data)
   renderConversationsCharts(data)
   renderConversationsListTable(data.conversations)
+}
+
+function renderAgentMetrics(metrics) {
+  const container = document.getElementById('agent-metrics-cards')
+  const section = document.getElementById('agent-metrics-section')
+  if (!metrics || !container || !section) return
+
+  // Destroy previous sparkline charts
+  for (let i = 0; i < 4; i++) {
+    destroyChart('agentSparkline' + i)
+  }
+
+  const items = [
+    { title: 'Tool Diversity', value: metrics.tool_diversity_index, detail: 'unique tools / total uses', key: 'tool_diversity_index', color: '#D97706' },
+    { title: 'Plan Mode Adoption', value: metrics.plan_mode_adoption_rate, detail: 'conversations using plan mode', key: 'plan_mode_adoption_rate', color: '#2563EB' },
+    { title: 'Cache Efficiency', value: metrics.avg_cache_hit_rate, detail: 'average cache hit rate', key: 'avg_cache_hit_rate', color: '#059669' },
+    { title: 'Thinking Utilization', value: metrics.thinking_utilization_rate, detail: 'responses using extended thinking', key: 'thinking_utilization_rate', color: '#7C3AED' }
+  ]
+
+  container.innerHTML = items.map(function(item, i) {
+    return '<div class="pace-card">' +
+      '<div class="pace-card-title">' + escapeHtml(item.title) + '</div>' +
+      '<div class="pace-card-value">' + escapeHtml(String(Math.round(item.value * 100))) + '%</div>' +
+      '<div class="pace-card-detail">' + escapeHtml(item.detail) + '</div>' +
+      '<div style="height:40px; margin-top:8px"><canvas id="agent-sparkline-' + i + '" style="width:100%; height:40px"></canvas></div>' +
+      '</div>'
+  }).join('')
+
+  if (metrics.weekly && metrics.weekly.length > 1) {
+    items.forEach(function(item, i) {
+      var canvas = document.getElementById('agent-sparkline-' + i)
+      if (!canvas) return
+      var weeks = metrics.weekly.map(function(w) { return w.week })
+      var values = metrics.weekly.map(function(w) { return w[item.key] })
+      charts['agentSparkline' + i] = new Chart(canvas.getContext('2d'), {
+        type: 'line',
+        data: {
+          labels: weeks,
+          datasets: [{
+            data: values,
+            borderColor: item.color,
+            borderWidth: 1.5,
+            pointRadius: 0,
+            tension: 0.3,
+            fill: false
+          }]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: { legend: { display: false }, tooltip: { enabled: false } },
+          scales: { x: { display: false }, y: { display: false } }
+        }
+      })
+    })
+  }
+
+  section.style.display = ''
 }
 
 function renderConversationsSummaryCards(data) {

--- a/vscode-extension/media/index.html
+++ b/vscode-extension/media/index.html
@@ -182,6 +182,10 @@
           <p>Browse your Claude Code conversations — structure, patterns, and engagement over time.</p>
         </div>
         <div id="conversations-summary-cards" class="pace-grid" style="display:none; margin-bottom: 24px"></div>
+        <div id="agent-metrics-section" style="display:none; margin-bottom: 24px">
+          <h3>Agent Metrics</h3>
+          <div id="agent-metrics-cards" class="pace-grid"></div>
+        </div>
         <div id="conversations-charts-row" style="display:none">
           <div class="chart-container">
             <h3>Conversations per Week</h3>

--- a/vscode-extension/src/webviewProvider.ts
+++ b/vscode-extension/src/webviewProvider.ts
@@ -10,7 +10,7 @@ import { ScoreCache } from './cache'
 import { DataCache } from './dataCache'
 import { getDefaultShell, getShellArgs, escapePromptForShell, getClaudeCommand } from './platform'
 import { buildConversationAnalytics } from './analytics'
-import { computeAgentMetrics, AgentMetrics } from './agentMetrics'
+import { computeAgentMetrics, computeWeeklyAgentMetrics, AgentMetrics, WeeklyAgentMetrics } from './agentMetrics'
 import { getConfig, getDisplayConfig } from './config'
 
 export class CodeFluentViewProvider implements vscode.WebviewViewProvider {
@@ -412,7 +412,7 @@ export class CodeFluentViewProvider implements vscode.WebviewViewProvider {
     return response
   }
 
-  private async handleGetAgentMetrics(payload?: { project?: string }): Promise<AgentMetrics> {
+  private async handleGetAgentMetrics(payload?: { project?: string }): Promise<AgentMetrics & { weekly: WeeklyAgentMetrics[] }> {
     const project = payload?.project ?? this.getWorkspaceProjectName()
     const convData = getAllConversations(undefined, undefined, this.getSessionDataPath(), 200)
     this.dataCache.setConversations(convData)
@@ -420,7 +420,9 @@ export class CodeFluentViewProvider implements vscode.WebviewViewProvider {
     if (project) {
       conversations = conversations.filter((c: any) => c.project === project)
     }
-    return computeAgentMetrics(conversations)
+    const metrics = computeAgentMetrics(conversations)
+    const weekly = computeWeeklyAgentMetrics(conversations)
+    return { ...metrics, weekly }
   }
 
   private async handleGetConversationAnalytics(payload?: { project?: string }) {

--- a/vscode-extension/test/unit/xss.test.ts
+++ b/vscode-extension/test/unit/xss.test.ts
@@ -404,4 +404,24 @@ describe('XSS vector coverage in webapp/static/app.js', () => {
     expect(src).toContain('escapeHtml(String(tools))')
     expect(src).toContain('escapeHtml(String(score))')
   })
+
+  test('agent-metrics-section exists in extension index.html', () => {
+    const htmlPath = path.resolve(__dirname, '../../media/index.html')
+    const html = fs.readFileSync(htmlPath, 'utf-8')
+    expect(html).toContain('id="agent-metrics-section"')
+    expect(html).toContain('id="agent-metrics-cards"')
+  })
+
+  test('agent-metrics-section has no inline onclick handlers', () => {
+    const htmlPath = path.resolve(__dirname, '../../media/index.html')
+    const html = fs.readFileSync(htmlPath, 'utf-8')
+    const section = html.match(/id="agent-metrics-section"[\s\S]*?<\/div>\s*<\/div>/)?.[0] || ''
+    expect(section).not.toMatch(/onclick\s*=/)
+  })
+
+  test('renderAgentMetrics escapes dynamic content', () => {
+    expect(src).toContain('escapeHtml(item.title)')
+    expect(src).toContain('escapeHtml(item.detail)')
+    expect(src).toMatch(/escapeHtml\(String\(Math\.round\(item\.value \* 100\)\)\)/)
+  })
 })

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -23,7 +23,7 @@ import subprocess
 from anthropic import Anthropic
 from extract_prompts import get_all_sessions
 from conversations import get_all_conversations
-from agent_metrics import compute_agent_metrics
+from agent_metrics import compute_agent_metrics, compute_weekly_agent_metrics
 
 BEHAVIORS = [
     "iteration_and_refinement", "clarifying_goals", "specifying_format",
@@ -548,7 +548,9 @@ async def get_agent_metrics(
         conversations = conv_data.get("conversations", [])
         if project:
             conversations = [c for c in conversations if c.get("project") == project]
-        return compute_agent_metrics(conversations)
+        result = compute_agent_metrics(conversations)
+        result["weekly"] = compute_weekly_agent_metrics(conversations)
+        return result
     except HTTPException:
         raise
     except Exception as e:

--- a/webapp/static/app.js
+++ b/webapp/static/app.js
@@ -1773,6 +1773,7 @@ function formatDuration(minutes) {
 async function loadConversationsExplorer() {
   document.getElementById('conversations-loading').style.display = ''
   document.getElementById('conversations-summary-cards').style.display = 'none'
+  document.getElementById('agent-metrics-section').style.display = 'none'
   document.getElementById('conversations-charts-row').style.display = 'none'
   document.getElementById('conversations-table-container').style.display = 'none'
   document.getElementById('conversations-empty').style.display = 'none'
@@ -1786,6 +1787,13 @@ async function loadConversationsExplorer() {
     if (!resp.ok) throw new Error('Failed to load')
     state.conversationsExplorer = await resp.json()
     renderConversationsExplorer()
+    try {
+      const agentResp = await fetch(`/api/agent-metrics?${params}`)
+      if (agentResp.ok) {
+        const agentData = await agentResp.json()
+        renderAgentMetrics(agentData)
+      }
+    } catch (_e) { /* agent metrics are supplementary */ }
   } catch (e) {
     document.getElementById('conversations-loading').style.display = 'none'
     document.getElementById('conversations-empty').style.display = ''
@@ -1805,6 +1813,64 @@ function renderConversationsExplorer() {
   renderConversationsSummaryCards(data)
   renderConversationsCharts(data)
   renderConversationsListTable(data.conversations)
+}
+
+function renderAgentMetrics(metrics) {
+  const container = document.getElementById('agent-metrics-cards')
+  const section = document.getElementById('agent-metrics-section')
+  if (!metrics || !container || !section) return
+
+  // Destroy previous sparkline charts
+  for (let i = 0; i < 4; i++) {
+    destroyChart('agentSparkline' + i)
+  }
+
+  const items = [
+    { title: 'Tool Diversity', value: metrics.tool_diversity_index, detail: 'unique tools / total uses', key: 'tool_diversity_index', color: '#D97706' },
+    { title: 'Plan Mode Adoption', value: metrics.plan_mode_adoption_rate, detail: 'conversations using plan mode', key: 'plan_mode_adoption_rate', color: '#2563EB' },
+    { title: 'Cache Efficiency', value: metrics.avg_cache_hit_rate, detail: 'average cache hit rate', key: 'avg_cache_hit_rate', color: '#059669' },
+    { title: 'Thinking Utilization', value: metrics.thinking_utilization_rate, detail: 'responses using extended thinking', key: 'thinking_utilization_rate', color: '#7C3AED' }
+  ]
+
+  container.innerHTML = items.map(function(item, i) {
+    return '<div class="pace-card">' +
+      '<div class="pace-card-title">' + escapeHtml(item.title) + '</div>' +
+      '<div class="pace-card-value">' + escapeHtml(String(Math.round(item.value * 100))) + '%</div>' +
+      '<div class="pace-card-detail">' + escapeHtml(item.detail) + '</div>' +
+      '<div style="height:40px; margin-top:8px"><canvas id="agent-sparkline-' + i + '" style="width:100%; height:40px"></canvas></div>' +
+      '</div>'
+  }).join('')
+
+  if (metrics.weekly && metrics.weekly.length > 1) {
+    items.forEach(function(item, i) {
+      var canvas = document.getElementById('agent-sparkline-' + i)
+      if (!canvas) return
+      var weeks = metrics.weekly.map(function(w) { return w.week })
+      var values = metrics.weekly.map(function(w) { return w[item.key] })
+      charts['agentSparkline' + i] = new Chart(canvas.getContext('2d'), {
+        type: 'line',
+        data: {
+          labels: weeks,
+          datasets: [{
+            data: values,
+            borderColor: item.color,
+            borderWidth: 1.5,
+            pointRadius: 0,
+            tension: 0.3,
+            fill: false
+          }]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: { legend: { display: false }, tooltip: { enabled: false } },
+          scales: { x: { display: false }, y: { display: false } }
+        }
+      })
+    })
+  }
+
+  section.style.display = ''
 }
 
 function renderConversationsSummaryCards(data) {

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -173,6 +173,10 @@
           <p>Browse your Claude Code conversations — structure, patterns, and engagement over time.</p>
         </div>
         <div id="conversations-summary-cards" class="pace-grid" style="display:none; margin-bottom: 24px"></div>
+        <div id="agent-metrics-section" style="display:none; margin-bottom: 24px">
+          <h3>Agent Metrics</h3>
+          <div id="agent-metrics-cards" class="pace-grid"></div>
+        </div>
         <div id="conversations-charts-row" style="display:none">
           <div class="chart-container">
             <h3>Conversations per Week</h3>

--- a/webapp/tests/test_api.py
+++ b/webapp/tests/test_api.py
@@ -934,6 +934,30 @@ class TestGetAgentMetrics:
         assert data["conversation_count"] == 0
         assert data["tool_diversity_index"] == 0
 
+    def test_returns_weekly_field(self, client, mock_sessions_dir):
+        resp = client.get("/api/agent-metrics", params={"data_path": str(mock_sessions_dir)})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "weekly" in data
+        assert isinstance(data["weekly"], list)
+        if len(data["weekly"]) > 0:
+            week = data["weekly"][0]
+            assert "week" in week
+            assert "tool_diversity_index" in week
+            assert "plan_mode_adoption_rate" in week
+            assert "avg_cache_hit_rate" in week
+            assert "thinking_utilization_rate" in week
+            assert "conversation_count" in week
+
+    def test_weekly_empty_when_no_data(self, client, tmp_path):
+        empty_dir = tmp_path / "empty_sessions"
+        empty_dir.mkdir()
+        resp = client.get("/api/agent-metrics", params={"data_path": str(empty_dir)})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "weekly" in data
+        assert data["weekly"] == []
+
     def test_project_filtering(self, client, mock_sessions_dir):
         resp = client.get("/api/agent-metrics", params={
             "data_path": str(mock_sessions_dir),

--- a/webapp/tests/test_security.py
+++ b/webapp/tests/test_security.py
@@ -268,3 +268,23 @@ class TestWebappXSSVectors:
         assert 'escapeHtml(cache)' in self.src
         assert 'escapeHtml(String(tools))' in self.src
         assert 'escapeHtml(String(score))' in self.src
+
+    def test_agent_metrics_section_exists_in_html(self):
+        html_path = Path(__file__).parent.parent / "static" / "index.html"
+        html = html_path.read_text()
+        assert 'id="agent-metrics-section"' in html
+        assert 'id="agent-metrics-cards"' in html
+
+    def test_agent_metrics_section_no_inline_onclick(self):
+        html_path = Path(__file__).parent.parent / "static" / "index.html"
+        html = html_path.read_text()
+        import re
+        section_match = re.search(r'id="agent-metrics-section".*?</div>\s*</div>', html, re.DOTALL)
+        if section_match:
+            assert not re.search(r'onclick\s*=', section_match.group(0))
+
+    def test_render_agent_metrics_escapes_dynamic_content(self):
+        assert 'escapeHtml(item.title)' in self.src
+        assert 'escapeHtml(item.detail)' in self.src
+        import re
+        assert re.search(r'escapeHtml\(String\(Math\.round\(item\.value \* 100\)\)\)', self.src)


### PR DESCRIPTION
## Summary

- Agent Metrics section in Conversations tab with 4 cards: tool diversity, plan mode adoption, cache efficiency, thinking utilization
- Each card shows percentage value + mini Chart.js sparkline showing weekly trend
- Extended `GET /api/agent-metrics` and `getAgentMetrics` IPC to include weekly data
- Feature parity across VS Code extension and webapp

## Test plan

- [x] CI passes (extension + webapp + security)
- [x] E2E webapp: Agent Metrics cards render below summary cards on Conversations tab
- [x] E2E webapp: Sparklines show trend lines
- [x] E2E webapp: Project filter updates agent metrics
- [x] VS Code extension: cards render with percentages and sparklines in sidebar

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)