### PR TITLE
feat: add duration distribution and avg length trend charts (#169)

### DIFF
--- a/vscode-extension/media/app.js
+++ b/vscode-extension/media/app.js
@@ -1895,6 +1895,95 @@ function renderConversationsCharts(data) {
     }
   })
 
+  // 3. Duration distribution (histogram)
+  const durationBins = [
+    { label: '<5m', min: 0, max: 5, count: 0 },
+    { label: '5-15m', min: 5, max: 15, count: 0 },
+    { label: '15-30m', min: 15, max: 30, count: 0 },
+    { label: '30m-1h', min: 30, max: 60, count: 0 },
+    { label: '1-2h', min: 60, max: 120, count: 0 },
+    { label: '2h+', min: 120, max: Infinity, count: 0 }
+  ]
+  convs.forEach(c => {
+    if (!c.started_at || !c.ended_at) return
+    const dur = (new Date(c.ended_at) - new Date(c.started_at)) / 60000
+    const bin = durationBins.find(b => dur >= b.min && dur < b.max)
+    if (bin) bin.count++
+  })
+
+  destroyChart('convDuration')
+  charts.convDuration = new Chart(document.getElementById('conv-duration-chart').getContext('2d'), {
+    type: 'bar',
+    data: {
+      labels: durationBins.map(b => b.label),
+      datasets: [{
+        label: 'Conversations',
+        data: durationBins.map(b => b.count),
+        backgroundColor: '#7C3AED',
+        borderRadius: 4
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: { legend: { display: false } },
+      scales: {
+        y: { beginAtZero: true, ticks: { stepSize: 1 } },
+        x: {}
+      }
+    }
+  })
+
+  // 4. Average conversation length trend (line chart)
+  const weeklyPrompts = {}
+  convs.forEach(c => {
+    if (!c.started_at) return
+    const d = new Date(c.started_at)
+    const dayOfWeek = d.getUTCDay() || 7
+    const monday = new Date(d)
+    monday.setUTCDate(d.getUTCDate() - dayOfWeek + 1)
+    const year = monday.getUTCFullYear()
+    const jan1 = new Date(Date.UTC(year, 0, 1))
+    const daysSinceJan1 = Math.floor((monday - jan1) / 86400000)
+    const weekNum = Math.ceil((daysSinceJan1 + jan1.getUTCDay() + 1) / 7)
+    const key = `${year}-W${String(weekNum).padStart(2, '0')}`
+    if (!weeklyPrompts[key]) weeklyPrompts[key] = { total: 0, count: 0 }
+    weeklyPrompts[key].total += (c.prompt_count || 0)
+    weeklyPrompts[key].count++
+  })
+  const avgWeeks = Object.keys(weeklyPrompts).sort()
+  const avgValues = avgWeeks.map(w => Math.round(weeklyPrompts[w].total / weeklyPrompts[w].count * 10) / 10)
+
+  destroyChart('convAvgLength')
+  if (avgWeeks.length > 0) {
+    charts.convAvgLength = new Chart(document.getElementById('conv-avg-length-chart').getContext('2d'), {
+      type: 'line',
+      data: {
+        labels: avgWeeks,
+        datasets: [{
+          label: 'Avg Prompts',
+          data: avgValues,
+          borderColor: '#2563EB',
+          backgroundColor: '#2563EB',
+          tension: 0.3,
+          pointRadius: 3,
+          pointHoverRadius: 6,
+          borderWidth: 2,
+          fill: false
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { display: false } },
+        scales: {
+          y: { beginAtZero: true },
+          x: { ticks: { maxRotation: 45 } }
+        }
+      }
+    })
+  }
+
   document.getElementById('conversations-charts-row').style.display = ''
 }
 

--- a/vscode-extension/media/index.html
+++ b/vscode-extension/media/index.html
@@ -195,6 +195,14 @@
             <h3>Conversation Length Distribution</h3>
             <canvas id="conv-length-chart"></canvas>
           </div>
+          <div class="chart-container">
+            <h3>Conversation Duration Distribution</h3>
+            <canvas id="conv-duration-chart"></canvas>
+          </div>
+          <div class="chart-container">
+            <h3>Average Prompts per Conversation</h3>
+            <canvas id="conv-avg-length-chart"></canvas>
+          </div>
         </div>
         <div id="conversations-table-container" style="display:none">
           <div class="table-wrapper">

--- a/vscode-extension/test/unit/xss.test.ts
+++ b/vscode-extension/test/unit/xss.test.ts
@@ -184,6 +184,8 @@ describe('XSS vector coverage in media/app.js (VS Code extension)', () => {
     expect(html).toContain('id="tab-conversations"')
     expect(html).toContain('id="conversations-list-table"')
     expect(html).toContain('data-tab="conversations"')
+    expect(html).toContain('id="conv-duration-chart"')
+    expect(html).toContain('id="conv-avg-length-chart"')
   })
 
   test('webapp conversations tab has no inline onclick handlers', () => {
@@ -397,6 +399,8 @@ describe('XSS vector coverage in webapp/static/app.js', () => {
     expect(html).toContain('id="conversations-list-table"')
     expect(html).toContain('id="conversations-summary-cards"')
     expect(html).toContain('data-tab="conversations"')
+    expect(html).toContain('id="conv-duration-chart"')
+    expect(html).toContain('id="conv-avg-length-chart"')
   })
 
   test('extension conversations tab has no inline onclick handlers', () => {

--- a/webapp/static/app.js
+++ b/webapp/static/app.js
@@ -1985,6 +1985,95 @@ function renderConversationsCharts(data) {
     }
   })
 
+  // 3. Duration distribution (histogram)
+  const durationBins = [
+    { label: '<5m', min: 0, max: 5, count: 0 },
+    { label: '5-15m', min: 5, max: 15, count: 0 },
+    { label: '15-30m', min: 15, max: 30, count: 0 },
+    { label: '30m-1h', min: 30, max: 60, count: 0 },
+    { label: '1-2h', min: 60, max: 120, count: 0 },
+    { label: '2h+', min: 120, max: Infinity, count: 0 }
+  ]
+  convs.forEach(c => {
+    if (!c.started_at || !c.ended_at) return
+    const dur = (new Date(c.ended_at) - new Date(c.started_at)) / 60000
+    const bin = durationBins.find(b => dur >= b.min && dur < b.max)
+    if (bin) bin.count++
+  })
+
+  destroyChart('convDuration')
+  charts.convDuration = new Chart(document.getElementById('conv-duration-chart').getContext('2d'), {
+    type: 'bar',
+    data: {
+      labels: durationBins.map(b => b.label),
+      datasets: [{
+        label: 'Conversations',
+        data: durationBins.map(b => b.count),
+        backgroundColor: '#7C3AED',
+        borderRadius: 4
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: { legend: { display: false } },
+      scales: {
+        y: { beginAtZero: true, ticks: { stepSize: 1 } },
+        x: {}
+      }
+    }
+  })
+
+  // 4. Average conversation length trend (line chart)
+  const weeklyPrompts = {}
+  convs.forEach(c => {
+    if (!c.started_at) return
+    const d = new Date(c.started_at)
+    const dayOfWeek = d.getUTCDay() || 7
+    const monday = new Date(d)
+    monday.setUTCDate(d.getUTCDate() - dayOfWeek + 1)
+    const year = monday.getUTCFullYear()
+    const jan1 = new Date(Date.UTC(year, 0, 1))
+    const daysSinceJan1 = Math.floor((monday - jan1) / 86400000)
+    const weekNum = Math.ceil((daysSinceJan1 + jan1.getUTCDay() + 1) / 7)
+    const key = `${year}-W${String(weekNum).padStart(2, '0')}`
+    if (!weeklyPrompts[key]) weeklyPrompts[key] = { total: 0, count: 0 }
+    weeklyPrompts[key].total += (c.prompt_count || 0)
+    weeklyPrompts[key].count++
+  })
+  const avgWeeks = Object.keys(weeklyPrompts).sort()
+  const avgValues = avgWeeks.map(w => Math.round(weeklyPrompts[w].total / weeklyPrompts[w].count * 10) / 10)
+
+  destroyChart('convAvgLength')
+  if (avgWeeks.length > 0) {
+    charts.convAvgLength = new Chart(document.getElementById('conv-avg-length-chart').getContext('2d'), {
+      type: 'line',
+      data: {
+        labels: avgWeeks,
+        datasets: [{
+          label: 'Avg Prompts',
+          data: avgValues,
+          borderColor: '#2563EB',
+          backgroundColor: '#2563EB',
+          tension: 0.3,
+          pointRadius: 3,
+          pointHoverRadius: 6,
+          borderWidth: 2,
+          fill: false
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { display: false } },
+        scales: {
+          y: { beginAtZero: true },
+          x: { ticks: { maxRotation: 45 } }
+        }
+      }
+    })
+  }
+
   document.getElementById('conversations-charts-row').style.display = ''
 }
 

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -186,6 +186,14 @@
             <h3>Conversation Length Distribution</h3>
             <canvas id="conv-length-chart"></canvas>
           </div>
+          <div class="chart-container">
+            <h3>Conversation Duration Distribution</h3>
+            <canvas id="conv-duration-chart"></canvas>
+          </div>
+          <div class="chart-container">
+            <h3>Average Prompts per Conversation</h3>
+            <canvas id="conv-avg-length-chart"></canvas>
+          </div>
         </div>
         <div id="conversations-table-container" style="display:none">
           <div class="table-wrapper">

--- a/webapp/tests/test_security.py
+++ b/webapp/tests/test_security.py
@@ -251,6 +251,8 @@ class TestWebappXSSVectors:
         assert 'id="tab-conversations"' in html
         assert 'id="conversations-list-table"' in html
         assert 'data-tab="conversations"' in html
+        assert 'id="conv-duration-chart"' in html
+        assert 'id="conv-avg-length-chart"' in html
 
     def test_conversations_tab_no_inline_onclick(self):
         html_path = Path(__file__).parent.parent / "static" / "index.html"


### PR DESCRIPTION
## Summary

- Two new charts in the Conversations tab, stacked vertically below existing charts:
  - **Conversation Duration Distribution** — histogram binning by wall-clock duration (<5m, 5-15m, 15-30m, 30m-1h, 1-2h, 2h+)
  - **Average Prompts per Conversation** — weekly trend line of mean prompt count
- All computation client-side from existing conversation data
- Feature parity across VS Code extension and webapp

## Test plan

- [x] CI passes (extension + webapp + security)
- [x] E2E webapp: Both new charts render below existing charts
- [x] VS Code extension: All 4 charts render stacked vertically with readable labels

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)