### PR TITLE
fix: use content hash for stable score cache lookup (#182)

### DIFF
--- a/vscode-extension/src/analytics.ts
+++ b/vscode-extension/src/analytics.ts
@@ -154,16 +154,23 @@ export function joinConversationsWithScores(
   configBehaviors?: Record<string, boolean>,
 ): EnrichedConversation[] {
   const scoreMap = new Map<string, number | null>()
+  // Build content_hash → score reverse index for fallback lookup
+  const hashScoreMap = new Map<string, number | null>()
   for (const score of scores) {
     if (score.overall_score == null) continue
     // Compute effective score: conversation behavior OR config behavior
+    let effectiveScore: number | null
     if (configBehaviors && score.fluency_behaviors) {
       const effectiveCount = BEHAVIORS.filter(b =>
         score.fluency_behaviors![b] || (CONFIG_ELIGIBLE_BEHAVIORS.has(b) && configBehaviors[b])
       ).length
-      scoreMap.set(score.session_id, Math.round((effectiveCount / BEHAVIORS.length) * 100))
+      effectiveScore = Math.round((effectiveCount / BEHAVIORS.length) * 100)
     } else {
-      scoreMap.set(score.session_id, score.overall_score ?? null)
+      effectiveScore = score.overall_score ?? null
+    }
+    scoreMap.set(score.session_id, effectiveScore)
+    if (score.content_hash) {
+      hashScoreMap.set(score.content_hash, effectiveScore)
     }
   }
 
@@ -192,9 +199,16 @@ export function joinConversationsWithScores(
       estimated_cost = cost.total_cost
     }
 
+    // Try direct ID lookup, then content_hash fallback
+    let overallScore = scoreMap.get(conv.id) ?? null
+    if (overallScore === null && 'content_hash' in conv) {
+      const hash = (conv as ParsedConversation).content_hash
+      if (hash) overallScore = hashScoreMap.get(hash) ?? null
+    }
+
     return {
       ...rest,
-      overall_score: scoreMap.get(conv.id) ?? null,
+      overall_score: overallScore,
       estimated_cost,
     }
   })

--- a/vscode-extension/src/conversation.ts
+++ b/vscode-extension/src/conversation.ts
@@ -5,6 +5,7 @@ import { TimestampedMessage, SessionMessagesResult, parseSessionMessages } from 
 
 export interface ParsedConversation {
   id: string
+  content_hash: string
   project: string
   project_path_encoded: string
   session_ids: string[]
@@ -39,6 +40,18 @@ export interface ConversationsResult {
     total_prompts: number
     extracted_at: string
   }
+}
+
+export function computeContentHash(
+  projectPathEncoded: string,
+  promptTimestamps: string[],
+  startedAt: string | null,
+  userPrompts: string[],
+  promptCount: number,
+): string {
+  const ts = promptTimestamps[0] || startedAt || 'unknown'
+  const prefix = (userPrompts[0] || '').slice(0, 50)
+  return `${projectPathEncoded}:${ts}:${promptCount}:${prefix}`
 }
 
 export function buildConversations(
@@ -141,8 +154,13 @@ export function buildConversations(
     const cacheHitDenom = totalCacheReadTokens + totalInputTokens + totalCacheCreationTokens
     const cacheHitRate = cacheHitDenom > 0 ? totalCacheReadTokens / cacheHitDenom : 0
 
+    const contentHash = computeContentHash(
+      projectPathEncoded, promptTimestamps.sort(), timestamps[0] || null, userPrompts, promptCount,
+    )
+
     conversations.push({
       id: '', // filled below with zero-padded index
+      content_hash: contentHash,
       project,
       project_path_encoded: projectPathEncoded,
       session_ids: Array.from(sessionIds).sort(),

--- a/vscode-extension/src/scoring.ts
+++ b/vscode-extension/src/scoring.ts
@@ -23,6 +23,7 @@ export interface ScoreResult {
   low_confidence?: boolean
   suspicious_perfect_score?: boolean
   prompt_version?: string
+  content_hash?: string
 }
 
 export interface AggregateResult {
@@ -310,14 +311,32 @@ export async function scoreConversations(
   const results: Record<string, ScoreResult> = {}
   const stats: ScoringStats = { scored: 0, cached: 0, skipped_no_prompts: 0, errored: 0 }
 
+  // Build content_hash → cached key reverse index for fallback lookup
+  const hashIndex: Record<string, string> = {}
+  for (const [key, entry] of Object.entries(cached)) {
+    if (entry.content_hash) hashIndex[entry.content_hash] = key
+  }
+
   for (const cid of conversationIds) {
-    if (cached[cid] && !forceRescore && cached[cid].prompt_version === SCORING_PROMPT_VERSION) {
-      results[cid] = cached[cid]
+    const conversation = allConversations[cid]
+    const contentHash = (conversation as any)?.content_hash as string | undefined
+
+    // Try direct ID lookup first, then fallback to content_hash
+    let cacheEntry = cached[cid]
+    if (!cacheEntry && contentHash && hashIndex[contentHash]) {
+      cacheEntry = cached[hashIndex[contentHash]]
+    }
+
+    if (cacheEntry && !forceRescore && cacheEntry.prompt_version === SCORING_PROMPT_VERSION) {
+      results[cid] = cacheEntry
+      // Re-key under new ID if found via hash fallback
+      if (!cached[cid]) {
+        cached[cid] = cacheEntry
+      }
       stats.cached++
       continue
     }
 
-    const conversation = allConversations[cid]
     if (!conversation || !conversation.user_prompts.length) {
       stats.skipped_no_prompts++
       continue
@@ -351,6 +370,7 @@ export async function scoreConversations(
       }
       const score = validateScoreResult(JSON.parse(text), cid, conversation.user_prompts.length)
       score.prompt_version = SCORING_PROMPT_VERSION
+      if (contentHash) score.content_hash = contentHash
       results[cid] = score
       cached[cid] = score
       stats.scored++
@@ -452,9 +472,13 @@ export function computeScoreHistory(
   configBehaviors?: Record<string, boolean>,
 ): ScoreHistoryEntry[] {
   const timestamps = new Map<string, string>()
+  const hashTimestamps = new Map<string, string>()
   for (const c of conversations) {
     if (c.started_at) {
       timestamps.set(c.id, c.started_at)
+      if ('content_hash' in c && (c as ParsedConversation).content_hash) {
+        hashTimestamps.set((c as ParsedConversation).content_hash, c.started_at)
+      }
     }
   }
 
@@ -463,7 +487,11 @@ export function computeScoreHistory(
 
   for (const [sid, score] of Object.entries(scores)) {
     if (!score.fluency_behaviors) continue
-    const timestamp = timestamps.get(sid)
+    let timestamp = timestamps.get(sid)
+    // Fallback: match via content_hash when ID has shifted
+    if (!timestamp && score.content_hash) {
+      timestamp = hashTimestamps.get(score.content_hash)
+    }
     if (!timestamp) continue
 
     const weekInfo = getISOWeekKey(timestamp)

--- a/vscode-extension/test/unit/agentMetrics.test.ts
+++ b/vscode-extension/test/unit/agentMetrics.test.ts
@@ -4,6 +4,7 @@ import { ParsedConversation } from '../../src/conversation'
 function makeConversation(overrides: Partial<ParsedConversation> = {}): ParsedConversation {
   return {
     id: 'conv-1',
+    content_hash: '-home-test-project:2026-01-06T10:00:00Z:2:hello world',
     project: 'test-project',
     project_path_encoded: '-home-test-project',
     session_ids: ['sess-1'],

--- a/vscode-extension/test/unit/analytics.test.ts
+++ b/vscode-extension/test/unit/analytics.test.ts
@@ -321,6 +321,22 @@ describe('joinSessionsWithScores', () => {
     expect(result[0].total_tokens).toBe(5000)
     expect(result[0].overall_score).toBe(90)
   })
+
+  it('falls back to content_hash when ID does not match score', () => {
+    const contentHash = '-home-test-project:2026-01-06T10:00:00Z:2:hello'
+    // Conversation has a new ID but same content_hash
+    const session = {
+      ...makeSession({ id: 'new-id' }),
+      content_hash: contentHash,
+      prompt_count: 2,
+      prompt_timestamps: ['2026-01-06T10:00:00Z'],
+    }
+    // Score was cached under old ID but has content_hash
+    const scores = [makeScoreResult({ session_id: 'old-id', overall_score: 85, content_hash: contentHash })]
+    const result = joinSessionsWithScores([session as any], scores)
+
+    expect(result[0].overall_score).toBe(85)
+  })
 })
 
 // --- buildSessionAnalytics ---

--- a/vscode-extension/test/unit/conversation.test.ts
+++ b/vscode-extension/test/unit/conversation.test.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import { parseSessionMessages, TimestampedMessage } from '../../src/parser'
-import { buildConversations, getAllConversations, ParsedConversation } from '../../src/conversation'
+import { buildConversations, getAllConversations, ParsedConversation, computeContentHash } from '../../src/conversation'
 
 const mockFs = fs as jest.Mocked<typeof fs>
 const mockOs = os as jest.Mocked<typeof os>
@@ -1011,5 +1011,107 @@ describe('getAllConversations', () => {
 
     const result = getAllConversations()
     expect(result.conversations).toHaveLength(1)
+  })
+})
+
+// ─── computeContentHash ────────────────────────────────────────────
+
+describe('computeContentHash', () => {
+  it('produces a stable hash from conversation properties', () => {
+    const hash = computeContentHash(
+      '-home-test-project',
+      ['2026-03-01T10:00:00.000Z'],
+      '2026-03-01T10:00:00.000Z',
+      ['Hello world'],
+      1,
+    )
+    expect(hash).toBe('-home-test-project:2026-03-01T10:00:00.000Z:1:Hello world')
+  })
+
+  it('uses first prompt timestamp over started_at', () => {
+    const hash = computeContentHash(
+      '-home-proj',
+      ['2026-03-01T10:05:00.000Z', '2026-03-01T10:10:00.000Z'],
+      '2026-03-01T10:00:00.000Z',
+      ['First prompt', 'Second prompt'],
+      2,
+    )
+    expect(hash).toContain('2026-03-01T10:05:00.000Z')
+    expect(hash).not.toContain('2026-03-01T10:00:00.000Z')
+  })
+
+  it('falls back to started_at when no prompt timestamps', () => {
+    const hash = computeContentHash('-home-proj', [], '2026-03-01T10:00:00.000Z', ['Prompt'], 1)
+    expect(hash).toContain('2026-03-01T10:00:00.000Z')
+  })
+
+  it('uses "unknown" when no timestamps available', () => {
+    const hash = computeContentHash('-home-proj', [], null, ['Prompt'], 1)
+    expect(hash).toContain(':unknown:')
+  })
+
+  it('truncates first prompt to 50 chars', () => {
+    const longPrompt = 'A'.repeat(100)
+    const hash = computeContentHash('-proj', ['ts'], null, [longPrompt], 1)
+    expect(hash).toBe(`-proj:ts:1:${'A'.repeat(50)}`)
+  })
+
+  it('handles empty user_prompts', () => {
+    const hash = computeContentHash('-proj', ['ts'], null, [], 0)
+    expect(hash).toBe('-proj:ts:0:')
+  })
+})
+
+// ─── content_hash in buildConversations ─────────────────────────────
+
+describe('buildConversations content_hash', () => {
+  function makeTimestampedMsg(type: string, timestamp: string, content?: string, extra: Record<string, any> = {}): any {
+    return {
+      type,
+      timestamp,
+      session_id: 'sess-1',
+      file_position: 0,
+      content: type === 'user' ? (content || 'Prompt') : undefined,
+      ...extra,
+    }
+  }
+
+  it('sets content_hash on each conversation', () => {
+    const messages = [
+      makeTimestampedMsg('user', '2026-03-01T10:00:00.000Z', 'Hello'),
+      makeTimestampedMsg('assistant', '2026-03-01T10:00:05.000Z'),
+    ]
+    const convs = buildConversations(messages, 'proj', '-home-proj', 60)
+    expect(convs).toHaveLength(1)
+    expect(convs[0].content_hash).toBe('-home-proj:2026-03-01T10:00:00.000Z:1:Hello')
+  })
+
+  it('content_hash is stable regardless of index position', () => {
+    // Two conversations from same project
+    const messages = [
+      makeTimestampedMsg('user', '2026-03-01T10:00:00.000Z', 'First conv'),
+      makeTimestampedMsg('assistant', '2026-03-01T10:00:05.000Z'),
+      // 2 hour gap -> new conversation
+      makeTimestampedMsg('user', '2026-03-01T12:00:00.000Z', 'Second conv'),
+      makeTimestampedMsg('assistant', '2026-03-01T12:00:05.000Z'),
+    ]
+    const convs = buildConversations(messages, 'proj', '-home-proj', 60)
+    expect(convs).toHaveLength(2)
+    const hash0 = convs[0].content_hash
+    const hash1 = convs[1].content_hash
+
+    // Now prepend a new conversation (simulating new data shifting indices)
+    const newMessages = [
+      makeTimestampedMsg('user', '2026-03-01T08:00:00.000Z', 'New early conv'),
+      makeTimestampedMsg('assistant', '2026-03-01T08:00:05.000Z'),
+      ...messages,
+    ]
+    const newConvs = buildConversations(newMessages, 'proj', '-home-proj', 60)
+    expect(newConvs).toHaveLength(3)
+
+    // IDs shifted (old conv:000 is now conv:001), but content_hashes remain the same
+    expect(newConvs[1].id).not.toBe(convs[0].id) // same content, different index-based ID
+    expect(newConvs[1].content_hash).toBe(hash0) // old conv 0 is now at index 1
+    expect(newConvs[2].content_hash).toBe(hash1) // old conv 1 is now at index 2
   })
 })

--- a/vscode-extension/test/unit/scoring.test.ts
+++ b/vscode-extension/test/unit/scoring.test.ts
@@ -209,6 +209,53 @@ describe('scoreSessions', () => {
     expect(results['sess-2'].overall_score).toBe(80)
   })
 
+  // --- content_hash cache fallback ---
+
+  it('falls back to content_hash when ID does not match cache', async () => {
+    const contentHash = '-home-test-project:2026-01-01T00:00:00Z:2:Implement a login page'
+    const cachedScore = makeScoreResult({ session_id: 'old-id', content_hash: contentHash, overall_score: 75 })
+    const client = makeMockClient(makeApiResponse({ overall_score: 50 }))
+    const sessions = {
+      'new-id': makeSession({ id: 'new-id', content_hash: contentHash } as any),
+    }
+
+    const { results, stats } = await scoreSessions(
+      ['new-id'], sessions, { 'old-id': cachedScore }, client
+    )
+
+    expect(client.messages.create).not.toHaveBeenCalled()
+    expect(results['new-id'].overall_score).toBe(75)
+    expect(stats.cached).toBe(1)
+  })
+
+  it('re-keys cached entry under new ID after hash fallback', async () => {
+    const contentHash = '-home-test-project:2026-01-01T00:00:00Z:2:Implement a login page'
+    const cachedScore = makeScoreResult({ session_id: 'old-id', content_hash: contentHash, overall_score: 75 })
+    const client = makeMockClient(makeApiResponse({ overall_score: 50 }))
+    const cached: Record<string, any> = { 'old-id': cachedScore }
+    const sessions = {
+      'new-id': makeSession({ id: 'new-id', content_hash: contentHash } as any),
+    }
+
+    await scoreSessions(['new-id'], sessions, cached, client)
+
+    expect(cached['new-id']).toBeDefined()
+    expect(cached['new-id'].overall_score).toBe(75)
+  })
+
+  it('stores content_hash on newly scored results', async () => {
+    const client = makeMockClient(makeApiResponse({ overall_score: 70 }))
+    const contentHash = '-home-test-project:2026-01-01T00:00:00Z:2:Implement a login page'
+    const sessions = {
+      'sess-1': makeSession({ content_hash: contentHash } as any),
+    }
+    const cached: Record<string, any> = {}
+
+    await scoreSessions(['sess-1'], sessions, cached, client)
+
+    expect(cached['sess-1'].content_hash).toBe(contentHash)
+  })
+
   // --- Skipping invalid sessions ---
 
   it('skips sessions not present in allSessions', async () => {

--- a/webapp/conversations.py
+++ b/webapp/conversations.py
@@ -9,6 +9,19 @@ from config import get_config
 CLAUDE_DATA_DIR = Path.home() / ".claude" / "projects"
 
 
+def compute_content_hash(
+    project_path_encoded: str,
+    prompt_timestamps: list[str],
+    started_at: str | None,
+    user_prompts: list[str],
+    prompt_count: int,
+) -> str:
+    """Compute a stable fingerprint for a conversation, independent of index position."""
+    ts = prompt_timestamps[0] if prompt_timestamps else (started_at or "unknown")
+    prefix = user_prompts[0][:50] if user_prompts else ""
+    return f"{project_path_encoded}:{ts}:{prompt_count}:{prefix}"
+
+
 def build_conversations(
     messages: list[dict],
     project: str,
@@ -120,8 +133,13 @@ def build_conversations(
         cache_hit_denom = total_cache_read_tokens + total_input_tokens + total_cache_creation_tokens
         cache_hit_rate = total_cache_read_tokens / cache_hit_denom if cache_hit_denom > 0 else 0
 
+        content_hash = compute_content_hash(
+            project_path_encoded, sorted(prompt_timestamps), timestamps[0] if timestamps else None, user_prompts, prompt_count,
+        )
+
         conversations.append({
             "id": "",  # filled below
+            "content_hash": content_hash,
             "project": project,
             "project_path_encoded": project_path_encoded,
             "session_ids": sorted(session_ids),

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -472,10 +472,20 @@ async def get_conversation_analytics(
                 config_behaviors = entry["fluency_behaviors"]
                 break  # Use first available config (typically one workspace)
 
+        # Build content_hash reverse index for score lookup fallback
+        score_hash_index = {}
+        for key, entry in cached_scores.items():
+            if entry.get("content_hash"):
+                score_hash_index[entry["content_hash"]] = key
+
         # Build session analytics with token data + optional score + cost
         analytics_sessions = []
         for s in sessions_list:
             score_entry = cached_scores.get(s["id"], {})
+            if not score_entry and s.get("content_hash"):
+                fallback_key = score_hash_index.get(s["content_hash"])
+                if fallback_key:
+                    score_entry = cached_scores.get(fallback_key, {})
             overall_score = None
             if "overall_score" in score_entry and score_entry.get("prompt_version") == SCORING_PROMPT_VERSION:
                 # Compute effective score: session behavior OR config behavior
@@ -715,13 +725,29 @@ async def score_conversations_endpoint(request: ScoreRequest):
     conv_data = get_all_conversations(data_dir)
     all_conversations = {c["id"]: c for c in conv_data["conversations"]}
 
+    # Build content_hash reverse index for fallback lookup
+    hash_index = {}
+    for key, entry in cached.items():
+        if entry.get("content_hash"):
+            hash_index[entry["content_hash"]] = key
+
     results = {}
     for sid in conversation_ids:
-        if sid in cached and not force and cached[sid].get("prompt_version") == SCORING_PROMPT_VERSION:
-            results[sid] = cached[sid]
+        session = all_conversations.get(sid)
+        content_hash = session.get("content_hash") if session else None
+
+        # Try direct ID lookup first, then content_hash fallback
+        cache_entry = cached.get(sid)
+        if not cache_entry and content_hash and content_hash in hash_index:
+            cache_entry = cached[hash_index[content_hash]]
+
+        if cache_entry and not force and cache_entry.get("prompt_version") == SCORING_PROMPT_VERSION:
+            results[sid] = cache_entry
+            # Re-key under new ID if found via hash fallback
+            if sid not in cached:
+                cached[sid] = cache_entry
             continue
 
-        session = all_conversations.get(sid)
         if not session or not session["user_prompts"]:
             continue
 
@@ -752,6 +778,8 @@ async def score_conversations_endpoint(request: ScoreRequest):
                 json.loads(text), sid, len(session.get("user_prompts", []))
             )
             score["prompt_version"] = SCORING_PROMPT_VERSION
+            if content_hash:
+                score["content_hash"] = content_hash
             results[sid] = score
             cached[sid] = score
         except Exception as e:

--- a/webapp/tests/test_conversations.py
+++ b/webapp/tests/test_conversations.py
@@ -739,3 +739,69 @@ class TestGetAllConversations:
         (tmp_path / "stray.txt").write_text("not a dir")
         result = get_all_conversations(data_dir=tmp_path, gap_minutes=60)
         assert result["metadata"]["total_conversations"] == 1
+
+
+# ─── compute_content_hash ───────────────────────────────────────────
+
+class TestComputeContentHash:
+    def test_basic_hash(self):
+        from conversations import compute_content_hash
+        h = compute_content_hash("-home-proj", ["2026-03-01T10:00:00.000Z"], "2026-03-01T10:00:00.000Z", ["Hello"], 1)
+        assert h == "-home-proj:2026-03-01T10:00:00.000Z:1:Hello"
+
+    def test_uses_first_prompt_timestamp(self):
+        from conversations import compute_content_hash
+        h = compute_content_hash("-proj", ["2026-03-01T10:05:00.000Z", "2026-03-01T10:10:00.000Z"], "2026-03-01T10:00:00.000Z", ["P1", "P2"], 2)
+        assert "10:05:00" in h
+        assert "10:00:00" not in h
+
+    def test_falls_back_to_started_at(self):
+        from conversations import compute_content_hash
+        h = compute_content_hash("-proj", [], "2026-03-01T10:00:00.000Z", ["P"], 1)
+        assert "2026-03-01T10:00:00.000Z" in h
+
+    def test_unknown_when_no_timestamps(self):
+        from conversations import compute_content_hash
+        h = compute_content_hash("-proj", [], None, ["P"], 1)
+        assert ":unknown:" in h
+
+    def test_truncates_first_prompt(self):
+        from conversations import compute_content_hash
+        h = compute_content_hash("-proj", ["ts"], None, ["A" * 100], 1)
+        assert h == f"-proj:ts:1:{'A' * 50}"
+
+
+class TestContentHashInBuildConversations:
+    def test_content_hash_set_on_conversations(self):
+        msgs = [
+            _make_user_message("2026-03-01T10:00:00.000Z", "Hello"),
+            _make_assistant_message("2026-03-01T10:00:05.000Z"),
+        ]
+        convs = build_conversations(msgs, "proj", "-home-proj", 60)
+        assert len(convs) == 1
+        assert convs[0]["content_hash"] == "-home-proj:2026-03-01T10:00:00.000Z:1:Hello"
+
+    def test_content_hash_stable_after_reindex(self):
+        """When new data shifts indices, content_hash stays the same."""
+        msgs = [
+            _make_user_message("2026-03-01T10:00:00.000Z", "First"),
+            _make_assistant_message("2026-03-01T10:00:05.000Z"),
+            _make_user_message("2026-03-01T12:00:00.000Z", "Second"),
+            _make_assistant_message("2026-03-01T12:00:05.000Z"),
+        ]
+        convs = build_conversations(msgs, "proj", "-home-proj", 60)
+        assert len(convs) == 2
+        hash0, hash1 = convs[0]["content_hash"], convs[1]["content_hash"]
+
+        # Add a new earlier conversation
+        new_msgs = [
+            _make_user_message("2026-03-01T08:00:00.000Z", "New early"),
+            _make_assistant_message("2026-03-01T08:00:05.000Z"),
+        ] + msgs
+        new_convs = build_conversations(new_msgs, "proj", "-home-proj", 60)
+        assert len(new_convs) == 3
+
+        # IDs shifted (old conv:000 is now conv:001) but hashes stayed the same
+        assert new_convs[1]["id"] != convs[0]["id"]  # same content, different index-based ID
+        assert new_convs[1]["content_hash"] == hash0
+        assert new_convs[2]["content_hash"] == hash1


### PR DESCRIPTION
## Summary

Conversation IDs are index-based (`conv:000`, `conv:001`) and shift when new session data is added between scoring runs. This caused cached scores to not display in the Conversations tab and Usage tab because the ID-based cache lookup failed.

**Fix:** Added a `content_hash` field to `ParsedConversation` that provides a stable fingerprint based on:
- First prompt timestamp
- Prompt count
- First 50 chars of first prompt
- Project path

Score cache lookups now try direct ID first, then fall back to a content_hash reverse index. Matched entries are re-keyed under the new ID for future lookups. Applied to:
- `scoreConversations()` in TypeScript and Python
- `joinConversationsWithScores()` in analytics.ts
- `/api/conversation-analytics` endpoint in webapp
- `/api/score` endpoint in webapp

## Test plan

- [x] CI passes (extension + webapp + security)
- [x] New tests: content_hash computation (stable, handles edge cases)
- [x] New tests: cache fallback via content_hash when ID doesn't match
- [x] New tests: re-keying under new ID after hash match
- [x] VS Code extension: scores display in Conversations tab after new sessions added

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)