### PR TITLE
feat: treat /clear commands as conversation boundaries (#194)

### DIFF
--- a/vscode-extension/src/conversation.ts
+++ b/vscode-extension/src/conversation.ts
@@ -82,12 +82,20 @@ export function buildConversations(
   let lastUserTimestamp: number | null = null
 
   for (const msg of sorted) {
-    if (msg.type === 'user' && msg.timestamp) {
-      const ts = new Date(msg.timestamp).getTime()
-      if (lastUserTimestamp !== null && (ts - lastUserTimestamp) > gapMs) {
+    if (msg.type === 'user') {
+      // /clear always forces a new conversation boundary
+      if (msg.is_clear_command) {
         buckets.push([])
+        buckets[buckets.length - 1].push(msg)
+        continue
       }
-      lastUserTimestamp = ts
+      if (msg.timestamp) {
+        const ts = new Date(msg.timestamp).getTime()
+        if (lastUserTimestamp !== null && (ts - lastUserTimestamp) > gapMs) {
+          buckets.push([])
+        }
+        lastUserTimestamp = ts
+      }
     }
     buckets[buckets.length - 1].push(msg)
   }
@@ -119,6 +127,7 @@ export function buildConversations(
       if (msg.timestamp) timestamps.push(msg.timestamp)
 
       if (msg.type === 'user') {
+        if (msg.is_clear_command) continue
         userMsgCount++
         if (msg.content) userPrompts.push(msg.content)
         if (msg.content && msg.timestamp) promptTimestamps.push(msg.timestamp)

--- a/vscode-extension/src/parser.ts
+++ b/vscode-extension/src/parser.ts
@@ -45,6 +45,7 @@ export interface TimestampedMessage {
   // User message fields
   content?: string              // extracted text (truncated to 2000 chars)
   used_plan_mode?: boolean      // true if planContent present
+  is_clear_command?: boolean    // true if /clear command
   // Assistant message fields
   usage?: { input_tokens: number; output_tokens: number;
             cache_creation_input_tokens: number; cache_read_input_tokens: number }
@@ -82,6 +83,10 @@ export function extractUserText(content: unknown): string {
     return parts.join(' ')
   }
   return ''
+}
+
+export function isClearCommand(text: string): boolean {
+  return /<command-name>\/clear<\/command-name>/.test(text)
 }
 
 export function parseSessionFile(filepath: string): ParsedSession | null {
@@ -138,9 +143,10 @@ export function parseSessionFile(filepath: string): ParsedSession | null {
     if (msg.timestamp) timestamps.push(msg.timestamp)
 
     if (msgType === 'user') {
-      userMsgCount++
       const content = msg.message?.content ?? ''
       const text = extractUserText(content)
+      if (isClearCommand(text)) continue  // skip /clear commands entirely
+      userMsgCount++
       if (text && text !== '[Request interrupted by user for tool use]') {
         userPrompts.push(text.slice(0, 2000))
       }
@@ -279,13 +285,15 @@ export function parseSessionMessages(filepath: string): SessionMessagesResult | 
       const content = msg.message?.content ?? ''
       const text = extractUserText(content)
       const isInterrupted = text === '[Request interrupted by user for tool use]'
+      const isClear = isClearCommand(text)
       const extracted: TimestampedMessage = {
         type: 'user',
         timestamp: msg.timestamp || null,
         session_id: '', // filled after loop
         file_position: i,
-        content: (!text || isInterrupted) ? undefined : text.slice(0, 2000),
+        content: (!text || isInterrupted || isClear) ? undefined : text.slice(0, 2000),
         used_plan_mode: !!msg.planContent,
+        is_clear_command: isClear || undefined,
       }
       if (!version && msg.version) extracted.claude_code_version = msg.version
       if (!gitBranch && msg.gitBranch) extracted.git_branch = msg.gitBranch

--- a/vscode-extension/test/unit/conversation.test.ts
+++ b/vscode-extension/test/unit/conversation.test.ts
@@ -1115,3 +1115,105 @@ describe('buildConversations content_hash', () => {
     expect(newConvs[2].content_hash).toBe(hash1) // old conv 1 is now at index 2
   })
 })
+
+describe('/clear as conversation boundary', () => {
+  function makeMsg(type: string, ts: string, overrides: Partial<TimestampedMessage> = {}): TimestampedMessage {
+    return {
+      type,
+      timestamp: ts,
+      session_id: 'sess-1',
+      file_position: 0,
+      ...overrides,
+    }
+  }
+
+  it('splits conversation at /clear command', () => {
+    const messages: TimestampedMessage[] = [
+      makeMsg('user', '2026-01-01T10:00:00Z', { content: 'first prompt', file_position: 0 }),
+      makeMsg('user', '2026-01-01T10:05:00Z', { content: 'second prompt', file_position: 1 }),
+      makeMsg('user', '2026-01-01T10:06:00Z', { is_clear_command: true, file_position: 2 }),
+      makeMsg('user', '2026-01-01T10:07:00Z', { content: 'third prompt', file_position: 3 }),
+    ]
+    const convs = buildConversations(messages, 'test', '-test', 60)
+    expect(convs).toHaveLength(2)
+    expect(convs[0].user_prompts).toEqual(['first prompt', 'second prompt'])
+    expect(convs[1].user_prompts).toEqual(['third prompt'])
+  })
+
+  it('does not create empty conversation when /clear is at the start', () => {
+    const messages: TimestampedMessage[] = [
+      makeMsg('user', '2026-01-01T10:00:00Z', { is_clear_command: true, file_position: 0 }),
+      makeMsg('user', '2026-01-01T10:01:00Z', { content: 'first prompt', file_position: 1 }),
+    ]
+    const convs = buildConversations(messages, 'test', '-test', 60)
+    expect(convs).toHaveLength(1)
+    expect(convs[0].user_prompts).toEqual(['first prompt'])
+  })
+
+  it('does not create empty conversation when /clear is at the end', () => {
+    const messages: TimestampedMessage[] = [
+      makeMsg('user', '2026-01-01T10:00:00Z', { content: 'first prompt', file_position: 0 }),
+      makeMsg('user', '2026-01-01T10:05:00Z', { is_clear_command: true, file_position: 1 }),
+    ]
+    const convs = buildConversations(messages, 'test', '-test', 60)
+    expect(convs).toHaveLength(1)
+    expect(convs[0].user_prompts).toEqual(['first prompt'])
+  })
+
+  it('splits even without inactivity gap', () => {
+    const messages: TimestampedMessage[] = [
+      makeMsg('user', '2026-01-01T10:00:00Z', { content: 'prompt 1', file_position: 0 }),
+      makeMsg('user', '2026-01-01T10:00:30Z', { is_clear_command: true, file_position: 1 }),
+      makeMsg('user', '2026-01-01T10:01:00Z', { content: 'prompt 2', file_position: 2 }),
+    ]
+    // 60-minute gap, but /clear splits at 30 seconds
+    const convs = buildConversations(messages, 'test', '-test', 60)
+    expect(convs).toHaveLength(2)
+  })
+
+  it('does NOT split on /compact', () => {
+    const messages: TimestampedMessage[] = [
+      makeMsg('user', '2026-01-01T10:00:00Z', { content: 'prompt 1', file_position: 0 }),
+      makeMsg('user', '2026-01-01T10:05:00Z', { content: 'compact text', file_position: 1 }),
+      makeMsg('user', '2026-01-01T10:10:00Z', { content: 'prompt 2', file_position: 2 }),
+    ]
+    const convs = buildConversations(messages, 'test', '-test', 60)
+    expect(convs).toHaveLength(1)
+    expect(convs[0].user_prompts).toHaveLength(3)
+  })
+
+  it('handles multiple consecutive /clear commands', () => {
+    const messages: TimestampedMessage[] = [
+      makeMsg('user', '2026-01-01T10:00:00Z', { content: 'prompt 1', file_position: 0 }),
+      makeMsg('user', '2026-01-01T10:05:00Z', { is_clear_command: true, file_position: 1 }),
+      makeMsg('user', '2026-01-01T10:06:00Z', { is_clear_command: true, file_position: 2 }),
+      makeMsg('user', '2026-01-01T10:07:00Z', { content: 'prompt 2', file_position: 3 }),
+    ]
+    const convs = buildConversations(messages, 'test', '-test', 60)
+    expect(convs).toHaveLength(2)
+    expect(convs[0].user_prompts).toEqual(['prompt 1'])
+    expect(convs[1].user_prompts).toEqual(['prompt 2'])
+  })
+
+  it('does not count /clear in user_message_count', () => {
+    const messages: TimestampedMessage[] = [
+      makeMsg('user', '2026-01-01T10:00:00Z', { content: 'prompt 1', file_position: 0 }),
+      makeMsg('user', '2026-01-01T10:05:00Z', { is_clear_command: true, file_position: 1 }),
+      makeMsg('user', '2026-01-01T10:10:00Z', { content: 'prompt 2', file_position: 2 }),
+    ]
+    const convs = buildConversations(messages, 'test', '-test', 60)
+    expect(convs[0].user_message_count).toBe(1)
+    expect(convs[1].user_message_count).toBe(1)
+  })
+
+  it('does not include /clear in user_prompts', () => {
+    const messages: TimestampedMessage[] = [
+      makeMsg('user', '2026-01-01T10:00:00Z', { content: 'prompt 1', file_position: 0 }),
+      makeMsg('user', '2026-01-01T10:05:00Z', { is_clear_command: true, content: undefined, file_position: 1 }),
+      makeMsg('user', '2026-01-01T10:10:00Z', { content: 'prompt 2', file_position: 2 }),
+    ]
+    const convs = buildConversations(messages, 'test', '-test', 60)
+    const allPrompts = convs.flatMap(c => c.user_prompts)
+    expect(allPrompts).toEqual(['prompt 1', 'prompt 2'])
+  })
+})

--- a/vscode-extension/test/unit/parser.test.ts
+++ b/vscode-extension/test/unit/parser.test.ts
@@ -4,7 +4,7 @@ jest.mock('os')
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
-import { extractUserText, parseSessionFile, getAllSessions } from '../../src/parser'
+import { extractUserText, parseSessionFile, getAllSessions, isClearCommand } from '../../src/parser'
 
 const mockFs = fs as jest.Mocked<typeof fs>
 const mockOs = os as jest.Mocked<typeof os>
@@ -869,5 +869,30 @@ describe('getAllSessions', () => {
     expect(() => getAllSessions()).not.toThrow()
     const result = getAllSessions()
     expect(result.sessions).toHaveLength(2)
+  })
+})
+
+describe('isClearCommand', () => {
+  it('returns true for /clear command XML', () => {
+    const text = '<command-name>/clear</command-name>\n            <command-message>clear</command-message>\n            <command-args></command-args>'
+    expect(isClearCommand(text)).toBe(true)
+  })
+
+  it('returns false for /compact command XML', () => {
+    const text = '<command-name>/compact</command-name>\n            <command-message>compact</command-message>\n            <command-args></command-args>'
+    expect(isClearCommand(text)).toBe(false)
+  })
+
+  it('returns false for plain text containing clear', () => {
+    expect(isClearCommand('please clear the cache')).toBe(false)
+  })
+
+  it('returns false for empty string', () => {
+    expect(isClearCommand('')).toBe(false)
+  })
+
+  it('returns true when /clear tag is embedded in larger content', () => {
+    const text = 'some prefix <command-name>/clear</command-name> some suffix'
+    expect(isClearCommand(text)).toBe(true)
   })
 })

--- a/webapp/conversations.py
+++ b/webapp/conversations.py
@@ -56,11 +56,17 @@ def build_conversations(
     last_user_ts: float | None = None
 
     for msg in sorted_msgs:
-        if msg["type"] == "user" and msg.get("timestamp"):
-            ts = _ts_to_ms(msg["timestamp"])
-            if last_user_ts is not None and (ts - last_user_ts) > gap_ms:
+        if msg["type"] == "user":
+            # /clear always forces a new conversation boundary
+            if msg.get("is_clear_command"):
                 buckets.append([])
-            last_user_ts = ts
+                buckets[-1].append(msg)
+                continue
+            if msg.get("timestamp"):
+                ts = _ts_to_ms(msg["timestamp"])
+                if last_user_ts is not None and (ts - last_user_ts) > gap_ms:
+                    buckets.append([])
+                last_user_ts = ts
         buckets[-1].append(msg)
 
     # Build conversations from buckets
@@ -92,6 +98,8 @@ def build_conversations(
                 timestamps.append(msg["timestamp"])
 
             if msg["type"] == "user":
+                if msg.get("is_clear_command"):
+                    continue
                 user_msg_count += 1
                 if msg.get("content"):
                     user_prompts.append(msg["content"])

--- a/webapp/extract_prompts.py
+++ b/webapp/extract_prompts.py
@@ -44,6 +44,14 @@ def extract_user_text(message_content) -> str:
     return ""
 
 
+_CLEAR_COMMAND_RE = re.compile(r'<command-name>/clear</command-name>')
+
+
+def is_clear_command(text: str) -> bool:
+    """Check if the extracted user text is a /clear command."""
+    return bool(_CLEAR_COMMAND_RE.search(text))
+
+
 def parse_session_messages(filepath: Path) -> dict | None:
     """Parse a single JSONL session file and extract individual timestamped messages.
 
@@ -96,14 +104,17 @@ def parse_session_messages(filepath: Path) -> dict | None:
             content = msg.get("message", {}).get("content", "")
             text = extract_user_text(content)
             is_interrupted = text == "[Request interrupted by user for tool use]"
+            is_clear = is_clear_command(text)
             extracted = {
                 "type": "user",
                 "timestamp": msg.get("timestamp"),
                 "session_id": "",  # filled after loop
                 "file_position": i,
-                "content": None if (not text or is_interrupted) else text[:2000],
+                "content": None if (not text or is_interrupted or is_clear) else text[:2000],
                 "used_plan_mode": bool(msg.get("planContent")),
             }
+            if is_clear:
+                extracted["is_clear_command"] = True
             messages.append(extracted)
 
         elif msg_type == "assistant":
@@ -238,9 +249,11 @@ def parse_session_file(filepath: Path) -> dict | None:
             timestamps.append(timestamp)
 
         if msg_type == "user":
-            user_msg_count += 1
             content = msg.get("message", {}).get("content", "")
             text = extract_user_text(content)
+            if is_clear_command(text):
+                continue  # skip /clear commands entirely
+            user_msg_count += 1
             if text and text != "[Request interrupted by user for tool use]":
                 user_prompts.append(text[:2000])
             if msg.get("planContent"):

--- a/webapp/tests/test_conversations.py
+++ b/webapp/tests/test_conversations.py
@@ -805,3 +805,91 @@ class TestContentHashInBuildConversations:
         assert new_convs[1]["id"] != convs[0]["id"]  # same content, different index-based ID
         assert new_convs[1]["content_hash"] == hash0
         assert new_convs[2]["content_hash"] == hash1
+
+
+class TestClearConversationBoundary:
+    """Tests for /clear command as conversation boundary."""
+
+    def _make_msg(self, type, ts, **kwargs):
+        return {"type": type, "timestamp": ts, "session_id": "sess-1", "file_position": 0, **kwargs}
+
+    def test_splits_at_clear(self):
+        msgs = [
+            self._make_msg("user", "2026-01-01T10:00:00Z", content="first", file_position=0),
+            self._make_msg("user", "2026-01-01T10:05:00Z", content="second", file_position=1),
+            self._make_msg("user", "2026-01-01T10:06:00Z", is_clear_command=True, file_position=2),
+            self._make_msg("user", "2026-01-01T10:07:00Z", content="third", file_position=3),
+        ]
+        convs = build_conversations(msgs, "test", "-test", 60)
+        assert len(convs) == 2
+        assert convs[0]["user_prompts"] == ["first", "second"]
+        assert convs[1]["user_prompts"] == ["third"]
+
+    def test_no_empty_conversation_at_start(self):
+        msgs = [
+            self._make_msg("user", "2026-01-01T10:00:00Z", is_clear_command=True, file_position=0),
+            self._make_msg("user", "2026-01-01T10:01:00Z", content="first", file_position=1),
+        ]
+        convs = build_conversations(msgs, "test", "-test", 60)
+        assert len(convs) == 1
+        assert convs[0]["user_prompts"] == ["first"]
+
+    def test_no_empty_conversation_at_end(self):
+        msgs = [
+            self._make_msg("user", "2026-01-01T10:00:00Z", content="first", file_position=0),
+            self._make_msg("user", "2026-01-01T10:05:00Z", is_clear_command=True, file_position=1),
+        ]
+        convs = build_conversations(msgs, "test", "-test", 60)
+        assert len(convs) == 1
+        assert convs[0]["user_prompts"] == ["first"]
+
+    def test_splits_without_inactivity_gap(self):
+        msgs = [
+            self._make_msg("user", "2026-01-01T10:00:00Z", content="p1", file_position=0),
+            self._make_msg("user", "2026-01-01T10:00:30Z", is_clear_command=True, file_position=1),
+            self._make_msg("user", "2026-01-01T10:01:00Z", content="p2", file_position=2),
+        ]
+        convs = build_conversations(msgs, "test", "-test", 60)
+        assert len(convs) == 2
+
+    def test_compact_does_not_split(self):
+        msgs = [
+            self._make_msg("user", "2026-01-01T10:00:00Z", content="p1", file_position=0),
+            self._make_msg("user", "2026-01-01T10:05:00Z", content="compact text", file_position=1),
+            self._make_msg("user", "2026-01-01T10:10:00Z", content="p2", file_position=2),
+        ]
+        convs = build_conversations(msgs, "test", "-test", 60)
+        assert len(convs) == 1
+        assert len(convs[0]["user_prompts"]) == 3
+
+    def test_consecutive_clears(self):
+        msgs = [
+            self._make_msg("user", "2026-01-01T10:00:00Z", content="p1", file_position=0),
+            self._make_msg("user", "2026-01-01T10:05:00Z", is_clear_command=True, file_position=1),
+            self._make_msg("user", "2026-01-01T10:06:00Z", is_clear_command=True, file_position=2),
+            self._make_msg("user", "2026-01-01T10:07:00Z", content="p2", file_position=3),
+        ]
+        convs = build_conversations(msgs, "test", "-test", 60)
+        assert len(convs) == 2
+        assert convs[0]["user_prompts"] == ["p1"]
+        assert convs[1]["user_prompts"] == ["p2"]
+
+    def test_clear_not_counted_in_user_message_count(self):
+        msgs = [
+            self._make_msg("user", "2026-01-01T10:00:00Z", content="p1", file_position=0),
+            self._make_msg("user", "2026-01-01T10:05:00Z", is_clear_command=True, file_position=1),
+            self._make_msg("user", "2026-01-01T10:10:00Z", content="p2", file_position=2),
+        ]
+        convs = build_conversations(msgs, "test", "-test", 60)
+        assert convs[0]["user_message_count"] == 1
+        assert convs[1]["user_message_count"] == 1
+
+    def test_clear_not_in_user_prompts(self):
+        msgs = [
+            self._make_msg("user", "2026-01-01T10:00:00Z", content="p1", file_position=0),
+            self._make_msg("user", "2026-01-01T10:05:00Z", is_clear_command=True, file_position=1),
+            self._make_msg("user", "2026-01-01T10:10:00Z", content="p2", file_position=2),
+        ]
+        convs = build_conversations(msgs, "test", "-test", 60)
+        all_prompts = [p for c in convs for p in c["user_prompts"]]
+        assert all_prompts == ["p1", "p2"]

--- a/webapp/tests/test_extract_prompts.py
+++ b/webapp/tests/test_extract_prompts.py
@@ -10,6 +10,7 @@ from extract_prompts import (
     parse_session_file,
     get_all_sessions,
     _get_project_path_encoded,
+    is_clear_command,
 )
 
 
@@ -850,3 +851,25 @@ class TestGetAllSessions:
 
         result = get_all_sessions(tmp_path)
         assert result["metadata"]["total_sessions"] == 1
+
+
+class TestIsClearCommand:
+    """Tests for is_clear_command() detection."""
+
+    def test_true_for_clear_command(self):
+        text = '<command-name>/clear</command-name>\n            <command-message>clear</command-message>\n            <command-args></command-args>'
+        assert is_clear_command(text) is True
+
+    def test_false_for_compact_command(self):
+        text = '<command-name>/compact</command-name>\n            <command-message>compact</command-message>\n            <command-args></command-args>'
+        assert is_clear_command(text) is False
+
+    def test_false_for_plain_text(self):
+        assert is_clear_command("please clear the cache") is False
+
+    def test_false_for_empty_string(self):
+        assert is_clear_command("") is False
+
+    def test_true_when_embedded(self):
+        text = "prefix <command-name>/clear</command-name> suffix"
+        assert is_clear_command(text) is True


### PR DESCRIPTION
## Summary

Adds `/clear` commands as explicit conversation boundary signals. When a user issues `/clear`, the current conversation ends and a new one begins, regardless of inactivity gap timing. `/compact` is explicitly NOT a boundary — it's context management, not a conversation reset.

### Changes

**Parser layer:**
- New `isClearCommand()` / `is_clear_command()` helper detecting `<command-name>/clear</command-name>` XML tag
- `/clear` messages marked with `is_clear_command: true`, content set to `undefined`/`None` (excluded from `user_prompts`)
- `parseSessionFile` / `parse_session_file` skip `/clear` from `userMsgCount` and `userPrompts`

**Conversation assembly:**
- `/clear` forces a new bucket in `buildConversations` / `build_conversations` regardless of gap timing
- `/clear` does not update `lastUserTimestamp` — gap is measured from last real prompt
- `/clear` not counted in `user_message_count`
- Existing `userPrompts.length === 0` guard filters empty buckets (clear at start/end, consecutive clears)

### Motivation
- Users use `/clear` to explicitly start fresh — stronger boundary signal than inferred inactivity gaps
- After `/clear`, Claude has no memory of prior messages — scoring pre/post clear as one conversation is misleading
- Gives users explicit control over conversation boundaries and analytics
- Improves heuristic task classification accuracy (task type based on first 3 prompts of the actual conversation, not a merged super-conversation)

## Test plan

- [x] VS Code extension: 858 tests pass (was 845, +13 new)
- [x] Webapp: 698 tests pass (was 685, +13 new)
- [x] No existing test regressions
- [x] CI passes
- [x] `/clear` splits conversation at that point
- [x] `/clear` not included in `user_prompts`
- [x] `/clear` not counted in `user_message_count`
- [x] `/compact` does NOT trigger boundary
- [x] Multiple consecutive `/clear` handled (no empty conversations)
- [x] `/clear` at start/end doesn't create empty conversations
- [x] `/clear` splits even without inactivity gap
- [x] E2E: verified conversation boundaries align with /clear commands in real session data
- [x] VS Code extension: Conversations tab renders correctly with new boundaries

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)