### PR TITLE
fix: config maturity score not detecting hook matchers

### DIFF
--- a/vscode-extension/media/app.js
+++ b/vscode-extension/media/app.js
@@ -2394,7 +2394,7 @@ function computeMaturityScore(maturity, gaps) {
   const hookEvents = hooks.events || []
   const hookMultiEvent = hookEvents.length >= 2
   hookItems.push({ label: '2+ hook events', status: hookMultiEvent ? 'done' : hookEvents.length === 1 ? 'partial' : 'missing', detail: hookMultiEvent ? `${hookEvents.length} events: ${hookEvents.join(', ')}` : hookEvents.length === 1 ? `1 event: ${hookEvents[0]}` : 'Add hooks for multiple events' })
-  const hookMatchers = hooks.hasMatchers || false
+  const hookMatchers = hooks.matchers && hooks.matchers.length > 0
   hookItems.push({ label: 'File matchers', status: hookMatchers ? 'done' : 'missing', detail: hookMatchers ? 'Hooks use file pattern matching' : 'Add file matchers to scope hooks' })
   const hooksEarned = (hooksConfigured ? 10 : 0) + (hookMultiEvent ? 5 : hookEvents.length === 1 ? 2 : 0) + (hookMatchers ? 5 : 0)
   breakdown.push({ category: 'Hooks', earned: hooksEarned, max: 20, items: hookItems })

--- a/webapp/static/app.js
+++ b/webapp/static/app.js
@@ -2544,7 +2544,7 @@ function computeMaturityScore(maturity, gaps) {
   const hookEvents = hooks.events || []
   const hookMultiEvent = hookEvents.length >= 2
   hookItems.push({ label: '2+ hook events', status: hookMultiEvent ? 'done' : hookEvents.length === 1 ? 'partial' : 'missing', detail: hookMultiEvent ? `${hookEvents.length} events: ${hookEvents.join(', ')}` : hookEvents.length === 1 ? `1 event: ${hookEvents[0]}` : 'Add hooks for multiple events' })
-  const hookMatchers = hooks.hasMatchers || false
+  const hookMatchers = hooks.matchers && hooks.matchers.length > 0
   hookItems.push({ label: 'File matchers', status: hookMatchers ? 'done' : 'missing', detail: hookMatchers ? 'Hooks use file pattern matching' : 'Add file matchers to scope hooks' })
   const hooksEarned = (hooksConfigured ? 10 : 0) + (hookMultiEvent ? 5 : hookEvents.length === 1 ? 2 : 0) + (hookMatchers ? 5 : 0)
   breakdown.push({ category: 'Hooks', earned: hooksEarned, max: 20, items: hookItems })


### PR DESCRIPTION
## Summary

The config maturity scoring checked `hooks.hasMatchers` (a nonexistent boolean) instead of `hooks.matchers.length > 0` (the actual array from the scanner). This caused the "File matchers" checklist item to always show as missing even when matchers like `Edit|Write` were configured, costing 5 points.

Found during manual testing of adding a real hook to the project.

## Test plan

- [x] Both app.js files fixed
- [x] CI passes
- [x] Score increases by 5 when hook has matchers (verified: 27 → 32)

Fixes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)