### PR TITLE
feat: track custom command and skill usage as conversation signal

### DIFF
--- a/vscode-extension/media/app.js
+++ b/vscode-extension/media/app.js
@@ -2315,6 +2315,12 @@ function renderConversationDetailContent(conv) {
         <h4>Tools Used (${conv.tool_use_count || 0} invocations)</h4>
         <div class="detail-tools">${toolsHtml}</div>
       </div>
+      ${(conv.commands_used || []).length > 0 ? `<div class="detail-section">
+        <h4>Commands Used</h4>
+        <div class="detail-tools">${(conv.commands_used || []).map(c =>
+          `<span class="tool-tag">${escapeHtml(c)}</span>`
+        ).join('')}</div>
+      </div>` : ''}
       <div class="detail-section">
         <h4>User Prompts (${(conv.user_prompts || []).length})</h4>
         <div class="detail-prompts">${promptsHtml}</div>

--- a/vscode-extension/src/conversation.ts
+++ b/vscode-extension/src/conversation.ts
@@ -20,6 +20,7 @@ export interface ParsedConversation {
   assistant_message_count: number
   tool_use_count: number
   tools_used: string[]
+  commands_used: string[]
   thinking_count: number
   used_plan_mode: boolean
   model: string | null
@@ -110,6 +111,7 @@ export function buildConversations(
     let assistantMsgCount = 0
     let toolUseCount = 0
     const toolsUsed = new Set<string>()
+    const commandsUsed = new Set<string>()
     let thinkingCount = 0
     let usedPlanMode = false
     let model: string | null = null
@@ -132,6 +134,7 @@ export function buildConversations(
         if (msg.content) userPrompts.push(msg.content)
         if (msg.content && msg.timestamp) promptTimestamps.push(msg.timestamp)
         if (msg.used_plan_mode) usedPlanMode = true
+        if (msg.command_name) commandsUsed.add(msg.command_name)
       } else if (msg.type === 'assistant') {
         assistantMsgCount++
         if (msg.model && !model) model = msg.model
@@ -189,6 +192,7 @@ export function buildConversations(
       assistant_message_count: assistantMsgCount,
       tool_use_count: toolUseCount,
       tools_used: Array.from(toolsUsed).sort(),
+      commands_used: Array.from(commandsUsed).sort(),
       thinking_count: thinkingCount,
       used_plan_mode: usedPlanMode,
       model,

--- a/vscode-extension/src/parser.ts
+++ b/vscode-extension/src/parser.ts
@@ -13,6 +13,7 @@ export interface ParsedSession {
   assistant_message_count: number
   tool_use_count: number
   tools_used: string[]
+  commands_used: string[]
   thinking_count: number
   used_plan_mode: boolean
   model: string | null
@@ -46,6 +47,7 @@ export interface TimestampedMessage {
   content?: string              // extracted text (truncated to 2000 chars)
   used_plan_mode?: boolean      // true if planContent present
   is_clear_command?: boolean    // true if /clear command
+  command_name?: string         // e.g. '/rebuild' (custom commands/skills only)
   // Assistant message fields
   usage?: { input_tokens: number; output_tokens: number;
             cache_creation_input_tokens: number; cache_read_input_tokens: number }
@@ -93,6 +95,25 @@ export function isClearCommand(text: string): boolean {
   return /<command-name>\/clear<\/command-name>/.test(text)
 }
 
+/** Known system commands — meta-operations, not interactions with Claude. */
+export const SYSTEM_COMMANDS = new Set([
+  '/clear', '/compact', '/exit', '/login', '/logout',
+  '/status', '/init', '/help', '/cost', '/doctor',
+  '/config', '/memory', '/permissions', '/review',
+  '/terminal-setup', '/listen', '/mcp', '/vim',
+])
+
+export function extractCommandName(text: string): string | null {
+  const match = text.match(/<command-name>(\/[^<]+)<\/command-name>/)
+  return match ? match[1] : null
+}
+
+export function isCustomCommand(text: string): boolean {
+  const name = extractCommandName(text)
+  if (!name) return false
+  return !SYSTEM_COMMANDS.has(name)
+}
+
 export function parseSessionFile(filepath: string): ParsedSession | null {
   let raw: string
   try {
@@ -120,6 +141,7 @@ export function parseSessionFile(filepath: string): ParsedSession | null {
   const timestamps: string[] = []
   let toolUseCount = 0
   const toolsUsed = new Set<string>()
+  const commandsUsed = new Set<string>()
   let thinkingCount = 0
   let userMsgCount = 0
   let assistantMsgCount = 0
@@ -149,7 +171,13 @@ export function parseSessionFile(filepath: string): ParsedSession | null {
     if (msgType === 'user') {
       const content = msg.message?.content ?? ''
       const text = extractUserText(content)
-      if (isSlashCommand(text)) continue  // skip all slash commands (not natural language prompts)
+      if (isSlashCommand(text)) {
+        const cmdName = extractCommandName(text)
+        if (cmdName && !SYSTEM_COMMANDS.has(cmdName)) {
+          commandsUsed.add(cmdName)
+        }
+        continue  // skip all slash commands (not natural language prompts)
+      }
       userMsgCount++
       if (text && text !== '[Request interrupted by user for tool use]') {
         userPrompts.push(text.slice(0, 2000))
@@ -229,6 +257,7 @@ export function parseSessionFile(filepath: string): ParsedSession | null {
     assistant_message_count: assistantMsgCount,
     tool_use_count: toolUseCount,
     tools_used: Array.from(toolsUsed).sort(),
+    commands_used: Array.from(commandsUsed).sort(),
     thinking_count: thinkingCount,
     used_plan_mode: usedPlanMode,
     model,
@@ -291,6 +320,8 @@ export function parseSessionMessages(filepath: string): SessionMessagesResult | 
       const isInterrupted = text === '[Request interrupted by user for tool use]'
       const isCommand = isSlashCommand(text)
       const isClear = isCommand && isClearCommand(text)
+      const cmdName = isCommand ? extractCommandName(text) : null
+      const isCustom = cmdName ? !SYSTEM_COMMANDS.has(cmdName) : false
       const extracted: TimestampedMessage = {
         type: 'user',
         timestamp: msg.timestamp || null,
@@ -299,6 +330,7 @@ export function parseSessionMessages(filepath: string): SessionMessagesResult | 
         content: (!text || isInterrupted || isCommand) ? undefined : text.slice(0, 2000),
         used_plan_mode: !!msg.planContent,
         is_clear_command: isClear || undefined,
+        command_name: isCustom ? cmdName! : undefined,
       }
       if (!version && msg.version) extracted.claude_code_version = msg.version
       if (!gitBranch && msg.gitBranch) extracted.git_branch = msg.gitBranch

--- a/vscode-extension/test/unit/agentMetrics.test.ts
+++ b/vscode-extension/test/unit/agentMetrics.test.ts
@@ -17,6 +17,7 @@ function makeConversation(overrides: Partial<ParsedConversation> = {}): ParsedCo
     assistant_message_count: 3,
     tool_use_count: 5,
     tools_used: ['Read', 'Edit', 'Bash'],
+    commands_used: [],
     thinking_count: 1,
     used_plan_mode: false,
     model: 'claude-sonnet-4-20250514',

--- a/vscode-extension/test/unit/analytics.test.ts
+++ b/vscode-extension/test/unit/analytics.test.ts
@@ -14,6 +14,7 @@ function makeSession(overrides: Partial<ParsedSession> = {}): ParsedSession {
     assistant_message_count: 2,
     tool_use_count: 3,
     tools_used: ['Read', 'Edit'],
+    commands_used: [],
     thinking_count: 0,
     used_plan_mode: false,
     model: 'claude-sonnet-4-20250514',

--- a/vscode-extension/test/unit/conversation.test.ts
+++ b/vscode-extension/test/unit/conversation.test.ts
@@ -1217,3 +1217,40 @@ describe('/clear as conversation boundary', () => {
     expect(allPrompts).toEqual(['prompt 1', 'prompt 2'])
   })
 })
+
+describe('buildConversations commands_used', () => {
+  function makeMsg(type: string, ts: string, overrides: Partial<TimestampedMessage> = {}): TimestampedMessage {
+    return { type, timestamp: ts, session_id: 's1', file_position: 0, ...overrides }
+  }
+
+  it('aggregates command_name into commands_used', () => {
+    const messages = [
+      makeMsg('user', '2026-01-01T10:00:00Z', { content: 'hello', file_position: 0 }),
+      makeMsg('user', '2026-01-01T10:01:00Z', { command_name: '/rebuild', file_position: 1 }),
+      makeMsg('user', '2026-01-01T10:02:00Z', { content: 'another prompt', file_position: 2 }),
+    ]
+    const convs = buildConversations(messages, 'test', '-test', 60)
+    expect(convs).toHaveLength(1)
+    expect(convs[0].commands_used).toEqual(['/rebuild'])
+  })
+
+  it('deduplicates and sorts commands_used', () => {
+    const messages = [
+      makeMsg('user', '2026-01-01T10:00:00Z', { content: 'hello', file_position: 0 }),
+      makeMsg('user', '2026-01-01T10:01:00Z', { command_name: '/rebuild', file_position: 1 }),
+      makeMsg('user', '2026-01-01T10:02:00Z', { command_name: '/commit', file_position: 2 }),
+      makeMsg('user', '2026-01-01T10:03:00Z', { command_name: '/rebuild', file_position: 3 }),
+    ]
+    const convs = buildConversations(messages, 'test', '-test', 60)
+    expect(convs[0].commands_used).toEqual(['/commit', '/rebuild'])
+  })
+
+  it('returns empty commands_used when no custom commands', () => {
+    const messages = [
+      makeMsg('user', '2026-01-01T10:00:00Z', { content: 'hello', file_position: 0 }),
+      makeMsg('user', '2026-01-01T10:01:00Z', { content: 'world', file_position: 1 }),
+    ]
+    const convs = buildConversations(messages, 'test', '-test', 60)
+    expect(convs[0].commands_used).toEqual([])
+  })
+})

--- a/vscode-extension/test/unit/parser.test.ts
+++ b/vscode-extension/test/unit/parser.test.ts
@@ -4,7 +4,7 @@ jest.mock('os')
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
-import { extractUserText, parseSessionFile, getAllSessions, isClearCommand, isSlashCommand } from '../../src/parser'
+import { extractUserText, parseSessionFile, getAllSessions, isClearCommand, isSlashCommand, extractCommandName, isCustomCommand, SYSTEM_COMMANDS } from '../../src/parser'
 
 const mockFs = fs as jest.Mocked<typeof fs>
 const mockOs = os as jest.Mocked<typeof os>
@@ -921,5 +921,96 @@ describe('isClearCommand', () => {
   it('returns true when /clear tag is embedded in larger content', () => {
     const text = 'some prefix <command-name>/clear</command-name> some suffix'
     expect(isClearCommand(text)).toBe(true)
+  })
+})
+
+describe('extractCommandName', () => {
+  it('extracts command name from XML tag', () => {
+    expect(extractCommandName('<command-name>/rebuild</command-name>')).toBe('/rebuild')
+  })
+
+  it('extracts skill name', () => {
+    expect(extractCommandName('<command-name>/review-labels</command-name>')).toBe('/review-labels')
+  })
+
+  it('extracts system command name', () => {
+    expect(extractCommandName('<command-name>/clear</command-name>')).toBe('/clear')
+  })
+
+  it('returns null for plain text', () => {
+    expect(extractCommandName('just a regular prompt')).toBeNull()
+  })
+
+  it('returns null for empty string', () => {
+    expect(extractCommandName('')).toBeNull()
+  })
+
+  it('extracts from surrounding text', () => {
+    const text = '<command-message>rebuild</command-message>\n<command-name>/rebuild</command-name>'
+    expect(extractCommandName(text)).toBe('/rebuild')
+  })
+})
+
+describe('isCustomCommand', () => {
+  it('returns true for custom commands', () => {
+    for (const cmd of ['/rebuild', '/review-labels', '/commit', '/deploy']) {
+      const text = `<command-name>${cmd}</command-name>`
+      expect(isCustomCommand(text)).toBe(true)
+    }
+  })
+
+  it('returns false for system commands', () => {
+    for (const cmd of SYSTEM_COMMANDS) {
+      const text = `<command-name>${cmd}</command-name>`
+      expect(isCustomCommand(text)).toBe(false)
+    }
+  })
+
+  it('returns false for plain text', () => {
+    expect(isCustomCommand('just a regular prompt')).toBe(false)
+  })
+
+  it('returns false for empty string', () => {
+    expect(isCustomCommand('')).toBe(false)
+  })
+})
+
+describe('parseSessionFile commands_used', () => {
+  const sessionDir = '/mock/.claude/projects/-project-name'
+
+  it('tracks custom commands in commands_used', () => {
+    mockFs.readFileSync.mockReturnValue([
+      JSON.stringify({ type: 'user', sessionId: 's1', cwd: '/project', message: { content: '<command-message>rebuild</command-message>\n<command-name>/rebuild</command-name>' }, timestamp: '2026-01-01T00:00:00Z' }),
+      JSON.stringify({ type: 'user', isMeta: true, message: { content: [{ type: 'text', text: 'Compile the extension' }] }, timestamp: '2026-01-01T00:00:00Z' }),
+      JSON.stringify({ type: 'user', message: { content: 'a real prompt' }, timestamp: '2026-01-01T00:01:00Z' }),
+    ].join('\n'))
+
+    const result = parseSessionFile(path.join(sessionDir, 's1.jsonl'))
+    expect(result).not.toBeNull()
+    expect(result!.commands_used).toEqual(['/rebuild'])
+  })
+
+  it('returns empty commands_used for system commands only', () => {
+    mockFs.readFileSync.mockReturnValue([
+      JSON.stringify({ type: 'user', sessionId: 's1', cwd: '/project', message: { content: '<command-name>/clear</command-name>' }, timestamp: '2026-01-01T00:00:00Z' }),
+      JSON.stringify({ type: 'user', message: { content: 'a real prompt' }, timestamp: '2026-01-01T00:01:00Z' }),
+    ].join('\n'))
+
+    const result = parseSessionFile(path.join(sessionDir, 's1.jsonl'))
+    expect(result).not.toBeNull()
+    expect(result!.commands_used).toEqual([])
+  })
+
+  it('deduplicates and sorts multiple custom commands', () => {
+    mockFs.readFileSync.mockReturnValue([
+      JSON.stringify({ type: 'user', sessionId: 's1', cwd: '/project', message: { content: '<command-name>/rebuild</command-name>' }, timestamp: '2026-01-01T00:00:00Z' }),
+      JSON.stringify({ type: 'user', message: { content: '<command-name>/commit</command-name>' }, timestamp: '2026-01-01T00:01:00Z' }),
+      JSON.stringify({ type: 'user', message: { content: '<command-name>/rebuild</command-name>' }, timestamp: '2026-01-01T00:02:00Z' }),
+      JSON.stringify({ type: 'user', message: { content: 'a real prompt' }, timestamp: '2026-01-01T00:03:00Z' }),
+    ].join('\n'))
+
+    const result = parseSessionFile(path.join(sessionDir, 's1.jsonl'))
+    expect(result).not.toBeNull()
+    expect(result!.commands_used).toEqual(['/commit', '/rebuild'])
   })
 })

--- a/vscode-extension/test/unit/scoring.test.ts
+++ b/vscode-extension/test/unit/scoring.test.ts
@@ -15,6 +15,7 @@ function makeSession(overrides: Partial<ParsedSession> = {}): ParsedSession {
     assistant_message_count: 2,
     tool_use_count: 3,
     tools_used: ['Read', 'Edit', 'Bash'],
+    commands_used: [],
     thinking_count: 1,
     used_plan_mode: false,
     model: 'claude-sonnet-4-20250514',

--- a/webapp/conversations.py
+++ b/webapp/conversations.py
@@ -79,6 +79,7 @@ def build_conversations(
         assistant_msg_count = 0
         tool_use_count = 0
         tools_used: set[str] = set()
+        commands_used: set[str] = set()
         thinking_count = 0
         used_plan_mode = False
         model = None
@@ -107,6 +108,8 @@ def build_conversations(
                         prompt_timestamps.append(msg["timestamp"])
                 if msg.get("used_plan_mode"):
                     used_plan_mode = True
+                if msg.get("command_name"):
+                    commands_used.add(msg["command_name"])
             elif msg["type"] == "assistant":
                 assistant_msg_count += 1
                 if msg.get("model") and not model:
@@ -162,6 +165,7 @@ def build_conversations(
             "assistant_message_count": assistant_msg_count,
             "tool_use_count": tool_use_count,
             "tools_used": sorted(tools_used),
+            "commands_used": sorted(commands_used),
             "thinking_count": thinking_count,
             "used_plan_mode": used_plan_mode,
             "model": model,

--- a/webapp/extract_prompts.py
+++ b/webapp/extract_prompts.py
@@ -58,6 +58,30 @@ def is_clear_command(text: str) -> bool:
     return bool(_CLEAR_COMMAND_RE.search(text))
 
 
+_COMMAND_NAME_RE = re.compile(r'<command-name>(/[^<]+)</command-name>')
+
+SYSTEM_COMMANDS = frozenset([
+    '/clear', '/compact', '/exit', '/login', '/logout',
+    '/status', '/init', '/help', '/cost', '/doctor',
+    '/config', '/memory', '/permissions', '/review',
+    '/terminal-setup', '/listen', '/mcp', '/vim',
+])
+
+
+def extract_command_name(text: str) -> str | None:
+    """Extract the command name from a <command-name> tag."""
+    match = _COMMAND_NAME_RE.search(text)
+    return match.group(1) if match else None
+
+
+def is_custom_command(text: str) -> bool:
+    """Check if the text contains a custom command (not a system command)."""
+    name = extract_command_name(text)
+    if not name:
+        return False
+    return name not in SYSTEM_COMMANDS
+
+
 def parse_session_messages(filepath: Path) -> dict | None:
     """Parse a single JSONL session file and extract individual timestamped messages.
 
@@ -112,6 +136,8 @@ def parse_session_messages(filepath: Path) -> dict | None:
             is_interrupted = text == "[Request interrupted by user for tool use]"
             is_command = is_slash_command(text)
             is_clear = is_command and is_clear_command(text)
+            cmd_name = extract_command_name(text) if is_command else None
+            is_custom = cmd_name is not None and cmd_name not in SYSTEM_COMMANDS
             extracted = {
                 "type": "user",
                 "timestamp": msg.get("timestamp"),
@@ -122,6 +148,8 @@ def parse_session_messages(filepath: Path) -> dict | None:
             }
             if is_clear:
                 extracted["is_clear_command"] = True
+            if is_custom:
+                extracted["command_name"] = cmd_name
             messages.append(extracted)
 
         elif msg_type == "assistant":
@@ -221,6 +249,7 @@ def parse_session_file(filepath: Path) -> dict | None:
     timestamps = []
     tool_use_count = 0
     tools_used = set()
+    commands_used = set()
     thinking_count = 0
     user_msg_count = 0
     assistant_msg_count = 0
@@ -259,6 +288,9 @@ def parse_session_file(filepath: Path) -> dict | None:
             content = msg.get("message", {}).get("content", "")
             text = extract_user_text(content)
             if is_slash_command(text):
+                cmd_name = extract_command_name(text)
+                if cmd_name and cmd_name not in SYSTEM_COMMANDS:
+                    commands_used.add(cmd_name)
                 continue  # skip all slash commands (not natural language prompts)
             user_msg_count += 1
             if text and text != "[Request interrupted by user for tool use]":
@@ -328,6 +360,7 @@ def parse_session_file(filepath: Path) -> dict | None:
         "assistant_message_count": assistant_msg_count,
         "tool_use_count": tool_use_count,
         "tools_used": sorted(tools_used),
+        "commands_used": sorted(commands_used),
         "thinking_count": thinking_count,
         "used_plan_mode": used_plan_mode,
         "model": model,

--- a/webapp/static/app.js
+++ b/webapp/static/app.js
@@ -2416,6 +2416,12 @@ function renderConversationDetailContent(conv) {
         <h4>Tools Used (${conv.tool_use_count || 0} invocations)</h4>
         <div class="detail-tools">${toolsHtml}</div>
       </div>
+      ${(conv.commands_used || []).length > 0 ? `<div class="detail-section">
+        <h4>Commands Used</h4>
+        <div class="detail-tools">${(conv.commands_used || []).map(c =>
+          `<span class="tool-tag">${escapeHtml(c)}</span>`
+        ).join('')}</div>
+      </div>` : ''}
       <div class="detail-section">
         <h4>User Prompts (${(conv.user_prompts || []).length})</h4>
         <div class="detail-prompts">${promptsHtml}</div>

--- a/webapp/tests/test_conversations.py
+++ b/webapp/tests/test_conversations.py
@@ -893,3 +893,37 @@ class TestClearConversationBoundary:
         convs = build_conversations(msgs, "test", "-test", 60)
         all_prompts = [p for c in convs for p in c["user_prompts"]]
         assert all_prompts == ["p1", "p2"]
+
+
+class TestBuildConversationsCommandsUsed:
+    def test_aggregates_command_names(self):
+        messages = [
+            _make_user_message("2026-01-01T10:00:00Z", "hello", pos=0),
+            {"type": "user", "timestamp": "2026-01-01T10:01:00Z", "session_id": "s1",
+             "file_position": 1, "command_name": "/rebuild"},
+            _make_user_message("2026-01-01T10:02:00Z", "another", pos=2),
+        ]
+        convs = build_conversations(messages, "test", "-test", 60)
+        assert len(convs) == 1
+        assert convs[0]["commands_used"] == ["/rebuild"]
+
+    def test_deduplicates_and_sorts(self):
+        messages = [
+            _make_user_message("2026-01-01T10:00:00Z", "hello", pos=0),
+            {"type": "user", "timestamp": "2026-01-01T10:01:00Z", "session_id": "s1",
+             "file_position": 1, "command_name": "/rebuild"},
+            {"type": "user", "timestamp": "2026-01-01T10:02:00Z", "session_id": "s1",
+             "file_position": 2, "command_name": "/commit"},
+            {"type": "user", "timestamp": "2026-01-01T10:03:00Z", "session_id": "s1",
+             "file_position": 3, "command_name": "/rebuild"},
+        ]
+        convs = build_conversations(messages, "test", "-test", 60)
+        assert convs[0]["commands_used"] == ["/commit", "/rebuild"]
+
+    def test_empty_when_no_custom_commands(self):
+        messages = [
+            _make_user_message("2026-01-01T10:00:00Z", "hello", pos=0),
+            _make_user_message("2026-01-01T10:01:00Z", "world", pos=1),
+        ]
+        convs = build_conversations(messages, "test", "-test", 60)
+        assert convs[0]["commands_used"] == []

--- a/webapp/tests/test_extract_prompts.py
+++ b/webapp/tests/test_extract_prompts.py
@@ -12,6 +12,9 @@ from extract_prompts import (
     _get_project_path_encoded,
     is_clear_command,
     is_slash_command,
+    extract_command_name,
+    is_custom_command,
+    SYSTEM_COMMANDS,
 )
 
 
@@ -897,3 +900,101 @@ class TestIsClearCommand:
     def test_true_when_embedded(self):
         text = "prefix <command-name>/clear</command-name> suffix"
         assert is_clear_command(text) is True
+
+
+class TestExtractCommandName:
+    """Tests for extract_command_name() extraction."""
+
+    def test_extracts_custom_command(self):
+        assert extract_command_name("<command-name>/rebuild</command-name>") == "/rebuild"
+
+    def test_extracts_skill_name(self):
+        assert extract_command_name("<command-name>/review-labels</command-name>") == "/review-labels"
+
+    def test_extracts_system_command(self):
+        assert extract_command_name("<command-name>/clear</command-name>") == "/clear"
+
+    def test_returns_none_for_plain_text(self):
+        assert extract_command_name("just a regular prompt") is None
+
+    def test_returns_none_for_empty_string(self):
+        assert extract_command_name("") is None
+
+    def test_extracts_from_surrounding_text(self):
+        text = "<command-message>rebuild</command-message>\n<command-name>/rebuild</command-name>"
+        assert extract_command_name(text) == "/rebuild"
+
+
+class TestIsCustomCommand:
+    """Tests for is_custom_command() detection."""
+
+    def test_true_for_custom_commands(self):
+        for cmd in ["/rebuild", "/review-labels", "/commit", "/deploy"]:
+            text = f"<command-name>{cmd}</command-name>"
+            assert is_custom_command(text) is True, f"{cmd} should be custom"
+
+    def test_false_for_system_commands(self):
+        for cmd in SYSTEM_COMMANDS:
+            text = f"<command-name>{cmd}</command-name>"
+            assert is_custom_command(text) is False, f"{cmd} should be system"
+
+    def test_false_for_plain_text(self):
+        assert is_custom_command("just a regular prompt") is False
+
+    def test_false_for_empty_string(self):
+        assert is_custom_command("") is False
+
+
+class TestParseSessionFileCommandsUsed:
+    """Tests for commands_used in parse_session_file."""
+
+    def test_tracks_custom_commands(self, tmp_path):
+        session = tmp_path / "project" / "s1.jsonl"
+        session.parent.mkdir(parents=True)
+        session.write_text("\n".join([
+            json.dumps({"type": "user", "sessionId": "s1", "cwd": "/project",
+                        "message": {"content": "<command-message>rebuild</command-message>\n<command-name>/rebuild</command-name>"},
+                        "timestamp": "2026-01-01T00:00:00Z"}),
+            json.dumps({"type": "user", "isMeta": True,
+                        "message": {"content": [{"type": "text", "text": "Compile the extension"}]},
+                        "timestamp": "2026-01-01T00:00:00Z"}),
+            json.dumps({"type": "user", "message": {"content": "a real prompt"},
+                        "timestamp": "2026-01-01T00:01:00Z"}),
+        ]))
+        result = parse_session_file(session)
+        assert result is not None
+        assert result["commands_used"] == ["/rebuild"]
+
+    def test_empty_for_system_commands_only(self, tmp_path):
+        session = tmp_path / "project" / "s1.jsonl"
+        session.parent.mkdir(parents=True)
+        session.write_text("\n".join([
+            json.dumps({"type": "user", "sessionId": "s1", "cwd": "/project",
+                        "message": {"content": "<command-name>/clear</command-name>"},
+                        "timestamp": "2026-01-01T00:00:00Z"}),
+            json.dumps({"type": "user", "message": {"content": "a real prompt"},
+                        "timestamp": "2026-01-01T00:01:00Z"}),
+        ]))
+        result = parse_session_file(session)
+        assert result is not None
+        assert result["commands_used"] == []
+
+    def test_deduplicates_and_sorts(self, tmp_path):
+        session = tmp_path / "project" / "s1.jsonl"
+        session.parent.mkdir(parents=True)
+        session.write_text("\n".join([
+            json.dumps({"type": "user", "sessionId": "s1", "cwd": "/project",
+                        "message": {"content": "<command-name>/rebuild</command-name>"},
+                        "timestamp": "2026-01-01T00:00:00Z"}),
+            json.dumps({"type": "user",
+                        "message": {"content": "<command-name>/commit</command-name>"},
+                        "timestamp": "2026-01-01T00:01:00Z"}),
+            json.dumps({"type": "user",
+                        "message": {"content": "<command-name>/rebuild</command-name>"},
+                        "timestamp": "2026-01-01T00:02:00Z"}),
+            json.dumps({"type": "user", "message": {"content": "a real prompt"},
+                        "timestamp": "2026-01-01T00:03:00Z"}),
+        ]))
+        result = parse_session_file(session)
+        assert result is not None
+        assert result["commands_used"] == ["/commit", "/rebuild"]


### PR DESCRIPTION
## Summary

Closes #206

Tracks custom command and skill invocations (e.g., `/rebuild`, `/review-labels`) as a conversation signal, separate from natural language prompt scoring.

- Add `extractCommandName()`, `isCustomCommand()`, and `SYSTEM_COMMANDS` helpers to distinguish custom commands/skills from system commands (`/clear`, `/compact`, etc.)
- Add `commands_used: string[]` to `ParsedSession` and `ParsedConversation`
- Add `command_name` field to `TimestampedMessage` for conversation-level aggregation
- Display "Commands Used" section in conversation detail view (both interfaces) when commands are present
- System commands remain filtered and untracked; `isMeta` expanded entries continue passing through for scoring (the expanded text IS the actual prompt)

### JSONL investigation findings
- Custom commands appear as two entries: raw `<command-name>` tag (filtered) + `isMeta: true` expanded prompt (scored)
- Simple skills (e.g., `/review-labels`) are structurally identical to custom commands
- Complex skills with `context: fork` may differ but couldn't be verified — tracked as follow-up (#217)

## Test plan

- [x] 907 VS Code extension tests pass (+16 new: extractCommandName, isCustomCommand, commands_used in parser + conversation)
- [x] 746 webapp tests pass (+16 new: same coverage in Python)
- [x] CI passes (Run Tests, Run Webapp Tests, security)
- [x] Verified TS parser: `/rebuild` detected with `command_name` on real session data, aggregated into conversation `commands_used`
- [x] Verified webapp API: `/api/conversations` returns `commands_used: ['/rebuild']` for codefluent, `['/review-labels']` for sportswear
- [x] Verified system commands (`/clear`, `/compact`) do NOT appear in `commands_used` (0 leaked across 82 conversations)
- [x] Manual: VS Code extension Conversations tab shows "Commands Used: /rebuild" section in conversation detail view (screenshot verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)