### PR TITLE
docs: add configuration settings reference to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Both interfaces support the same key settings with sensible defaults:
 | Scoring model | `claude-sonnet-4-20250514` | Model used for fluency scoring |
 | Max prompts per conversation | `20` | How many prompts are sent for scoring |
 | Optimizer threshold | `90` | Score above which prompts are "already effective" |
-| Conversation gap | `60 min` | Inactivity gap that defines a conversation boundary |
+| Conversation gap | `60 min` | Inactivity gap that defines a conversation boundary (⚠️ changes all metrics) |
 | Session data path | `~/.claude/projects/` | Where to find Claude Code session files |
 
 - **VS Code extension:** Search "CodeFluent" in Settings (`Ctrl+,`). See [`vscode-extension/README.md`](vscode-extension/README.md#extension-settings) for details.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,22 @@ uv run uvicorn main:app --reload --host 0.0.0.0 --port 8000
 
 Then open `http://localhost:8000` in your browser. Usage data is fetched on demand via the **Refresh** button in the Usage tab — no manual `ccusage` commands needed. See [`webapp/README.md`](webapp/README.md) for detailed setup instructions.
 
-### Configure (API Key)
+### Configure
+
+Both interfaces support the same key settings with sensible defaults:
+
+| Setting | Default | What it controls |
+|---------|---------|-----------------|
+| Scoring model | `claude-sonnet-4-20250514` | Model used for fluency scoring |
+| Max prompts per conversation | `20` | How many prompts are sent for scoring |
+| Optimizer threshold | `90` | Score above which prompts are "already effective" |
+| Conversation gap | `60 min` | Inactivity gap that defines a conversation boundary |
+| Session data path | `~/.claude/projects/` | Where to find Claude Code session files |
+
+- **VS Code extension:** Search "CodeFluent" in Settings (`Ctrl+,`). See [`vscode-extension/README.md`](vscode-extension/README.md#extension-settings) for details.
+- **Web app:** Environment variables or `webapp/config.json`. See [`webapp/README.md`](webapp/README.md#settings) for details.
+
+### API Key
 
 The extension looks for your API key in this order:
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -134,6 +134,8 @@ Search "CodeFluent" in VS Code Settings (`Ctrl+,`) to configure:
 | `codefluent.optimizer.alreadyGoodThreshold` | `90` | Score (0–100) at or above which prompts are considered already effective |
 | `codefluent.conversation.inactivityGapMinutes` | `60` | Minutes of inactivity that defines a conversation boundary |
 
+> **Warning:** Changing `inactivityGapMinutes` redefines how conversations are assembled, which affects all downstream metrics — fluency scores, analytics, agent metrics, and task classification. Cached scores will become stale and should be re-scored with "Force Rescore" enabled.
+
 ### API Key
 
 CodeFluent uses the following resolution order:

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -124,7 +124,19 @@ See [`docs/SESSION_DATA.md`](../docs/SESSION_DATA.md) for details on data availa
 
 ## Extension Settings
 
-CodeFluent uses the following API key resolution order:
+Search "CodeFluent" in VS Code Settings (`Ctrl+,`) to configure:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `codefluent.sessionDataPath` | `~/.claude/projects/` | Custom path to Claude Code session data directory |
+| `codefluent.scoring.model` | `claude-sonnet-4-20250514` | Model ID for fluency scoring API calls |
+| `codefluent.scoring.maxPromptsPerConversation` | `20` | Maximum prompts per conversation sent for scoring |
+| `codefluent.optimizer.alreadyGoodThreshold` | `90` | Score (0–100) at or above which prompts are considered already effective |
+| `codefluent.conversation.inactivityGapMinutes` | `60` | Minutes of inactivity that defines a conversation boundary |
+
+### API Key
+
+CodeFluent uses the following resolution order:
 
 1. `ANTHROPIC_API_KEY` environment variable
 2. `.env` file in your workspace root

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -139,6 +139,8 @@ The webapp reads settings from three sources (highest priority first):
 | `optimizer.alreadyGoodThreshold` | `CODEFLUENT_OPTIMIZER_ALREADYGOODTHRESHOLD` | `90` | Score (0–100) at or above which prompts are considered already effective |
 | `conversation.inactivityGapMinutes` | `CODEFLUENT_CONVERSATION_INACTIVITYGAPMINUTES` | `60` | Minutes of inactivity that defines a conversation boundary |
 
+> **Warning:** Changing `inactivityGapMinutes` redefines how conversations are assembled, which affects all downstream metrics — fluency scores, analytics, agent metrics, and task classification. Cached scores will become stale and should be re-scored with "Force Rescore" enabled.
+
 Example `webapp/config.json`:
 
 ```json

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -124,6 +124,30 @@ Everything runs locally. No data leaves your machine except the API calls to Ant
 
 ## Configuration
 
+### Settings
+
+The webapp reads settings from three sources (highest priority first):
+
+1. **Environment variables** — `CODEFLUENT_<KEY>` (dots become underscores, uppercase)
+2. **`webapp/config.json`** — Optional local file (not tracked in git)
+3. **`shared/defaults.json`** — Shared defaults
+
+| Setting | Env Variable | Default | Description |
+|---------|-------------|---------|-------------|
+| `scoring.model` | `CODEFLUENT_SCORING_MODEL` | `claude-sonnet-4-20250514` | Model ID for fluency scoring API calls |
+| `scoring.maxPromptsPerConversation` | `CODEFLUENT_SCORING_MAXPROMPTSPERCONVERSATION` | `20` | Maximum prompts per conversation sent for scoring |
+| `optimizer.alreadyGoodThreshold` | `CODEFLUENT_OPTIMIZER_ALREADYGOODTHRESHOLD` | `90` | Score (0–100) at or above which prompts are considered already effective |
+| `conversation.inactivityGapMinutes` | `CODEFLUENT_CONVERSATION_INACTIVITYGAPMINUTES` | `60` | Minutes of inactivity that defines a conversation boundary |
+
+Example `webapp/config.json`:
+
+```json
+{
+  "scoring.model": "claude-sonnet-4-20250514",
+  "conversation.inactivityGapMinutes": 45
+}
+```
+
 ### Port
 
 The server runs on port 8000 by default. Change it with the `PORT` environment variable:


### PR DESCRIPTION
## Summary

Closes #224

Documents the 5 user-facing configuration settings across all three README files. Internal tuning parameters (16 others in `shared/defaults.json`) are intentionally omitted.

- **`vscode-extension/README.md`** — Settings table with all 5 VS Code settings, descriptions, and defaults under "Extension Settings"
- **`webapp/README.md`** — New "Settings" subsection with 3-level resolution order (env vars → config.json → defaults), env var naming convention, and example config.json
- **`README.md`** — Summary table with links to interface-specific docs for details

## Test plan

- [x] No code changes — documentation only
- [x] Verify settings table renders correctly on GitHub
- [x] Verify links to interface-specific READMEs work

🤖 Generated with [Claude Code](https://claude.com/claude-code)