### PR TITLE
chore: add x-release-please-version markers for VSIX refs (#220)

### DIFF
--- a/.claude/commands/rebuild.md
+++ b/.claude/commands/rebuild.md
@@ -2,6 +2,6 @@ Compile the VS Code extension TypeScript, package the VSIX, and install it:
 
 1. `cd vscode-extension && npm run compile`
 2. `npx @vscode/vsce package --allow-missing-repository`
-3. `code --install-extension codefluent-1.0.1.vsix --force`
+3. `code --install-extension codefluent-1.0.1.vsix --force`    <!-- x-release-please-version -->
 
 Report success or failure for each step. After completion, remind me to reload the VS Code window.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ npm test                   # Jest (unit + integration, 907 tests)
 
 # Package and install
 npx @vscode/vsce package --allow-missing-repository
-code --install-extension codefluent-1.0.1.vsix
+code --install-extension codefluent-1.0.1.vsix    # x-release-please-version
 
 # Debug: press F5 in VS Code with vscode-extension/ open
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ cd codefluent/vscode-extension
 npm install
 npm run compile
 npx @vscode/vsce package --allow-missing-repository
-code --install-extension codefluent-*.vsix
+code --install-extension codefluent-1.0.1.vsix    # x-release-please-version
 ```
 
 **Windows (PowerShell):**
@@ -83,7 +83,7 @@ cd codefluent\vscode-extension
 npm install
 npm run compile
 npx @vscode/vsce package --allow-missing-repository
-code --install-extension codefluent-*.vsix
+code --install-extension codefluent-1.0.1.vsix    # x-release-please-version
 ```
 
 Then reload VS Code. The CodeFluent icon appears in the activity bar.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,22 @@
           "type": "json",
           "path": "vscode-extension/package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "generic",
+          "path": "README.md"
+        },
+        {
+          "type": "generic",
+          "path": "vscode-extension/README.md"
+        },
+        {
+          "type": "generic",
+          "path": "CLAUDE.md"
+        },
+        {
+          "type": "generic",
+          "path": ".claude/commands/rebuild.md"
         }
       ]
     }

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -18,7 +18,7 @@ CodeFluent parses your local Claude Code session files, scores your prompting be
 
 1. Install the `.vsix` package:
    ```
-   code --install-extension codefluent-*.vsix
+   code --install-extension codefluent-1.0.1.vsix    # x-release-please-version
    ```
 2. Open the CodeFluent sidebar by clicking the activity bar icon
 3. When prompted, enter your Anthropic API key (stored securely in VS Code SecretStorage)


### PR DESCRIPTION
## Summary
- Replace `codefluent-*.vsix` globs with exact version strings (`codefluent-1.0.1.vsix`) in README install instructions
- Add `x-release-please-version` markers to README.md, vscode-extension/README.md, CLAUDE.md, and .claude/commands/rebuild.md
- Register all 4 files as `generic` extra-files in `release-please-config.json`

Release Please will now auto-update these version strings in each release PR.

Closes #220

## Test plan
- [x] Verify `release-please-config.json` is valid JSON with correct paths
- [x] Confirm markers appear on the correct lines in all 4 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)