### PR TITLE
fix: invalidate cached scores when conversation content_hash changes

### DIFF
--- a/vscode-extension/src/scoring.ts
+++ b/vscode-extension/src/scoring.ts
@@ -327,7 +327,7 @@ export async function scoreConversations(
       cacheEntry = cached[hashIndex[contentHash]]
     }
 
-    const hashMatch = !contentHash || !cacheEntry?.content_hash || cacheEntry.content_hash === contentHash
+    const hashMatch = !contentHash || (cacheEntry?.content_hash === contentHash)
     if (cacheEntry && !forceRescore && cacheEntry.prompt_version === SCORING_PROMPT_VERSION && hashMatch) {
       results[cid] = cacheEntry
       // Re-key under new ID if found via hash fallback

--- a/vscode-extension/src/scoring.ts
+++ b/vscode-extension/src/scoring.ts
@@ -327,7 +327,8 @@ export async function scoreConversations(
       cacheEntry = cached[hashIndex[contentHash]]
     }
 
-    if (cacheEntry && !forceRescore && cacheEntry.prompt_version === SCORING_PROMPT_VERSION) {
+    const hashMatch = !contentHash || !cacheEntry?.content_hash || cacheEntry.content_hash === contentHash
+    if (cacheEntry && !forceRescore && cacheEntry.prompt_version === SCORING_PROMPT_VERSION && hashMatch) {
       results[cid] = cacheEntry
       // Re-key under new ID if found via hash fallback
       if (!cached[cid]) {

--- a/vscode-extension/test/unit/scoring.test.ts
+++ b/vscode-extension/test/unit/scoring.test.ts
@@ -257,6 +257,70 @@ describe('scoreSessions', () => {
     expect(cached['sess-1'].content_hash).toBe(contentHash)
   })
 
+  // --- content_hash staleness detection ---
+
+  it('invalidates cache when content_hash changes (conversation grew)', async () => {
+    const oldHash = '-home-test-project:2026-01-01T00:00:00Z:2:Implement a login page'
+    const newHash = '-home-test-project:2026-01-01T00:00:00Z:5:Implement a login page'
+    const cachedScore = makeScoreResult({ session_id: 'sess-1', content_hash: oldHash, overall_score: 75 })
+    const client = makeMockClient(makeApiResponse({ overall_score: 60 }))
+    const sessions = {
+      'sess-1': makeSession({ content_hash: newHash } as any),
+    }
+    const cached: Record<string, any> = { 'sess-1': cachedScore }
+
+    const { results, stats } = await scoreSessions(['sess-1'], sessions, cached, client)
+
+    expect(stats.scored).toBe(1)
+    expect(stats.cached).toBe(0)
+    expect(results['sess-1'].overall_score).toBe(60)
+  })
+
+  it('uses cache when content_hash matches', async () => {
+    const contentHash = '-home-test-project:2026-01-01T00:00:00Z:2:Implement a login page'
+    const cachedScore = makeScoreResult({ session_id: 'sess-1', content_hash: contentHash, overall_score: 75 })
+    const client = makeMockClient(makeApiResponse({ overall_score: 60 }))
+    const sessions = {
+      'sess-1': makeSession({ content_hash: contentHash } as any),
+    }
+    const cached: Record<string, any> = { 'sess-1': cachedScore }
+
+    const { results, stats } = await scoreSessions(['sess-1'], sessions, cached, client)
+
+    expect(stats.cached).toBe(1)
+    expect(stats.scored).toBe(0)
+    expect(results['sess-1'].overall_score).toBe(75)
+  })
+
+  it('uses cache when cache entry has no content_hash (legacy)', async () => {
+    const cachedScore = makeScoreResult({ session_id: 'sess-1', overall_score: 75 })
+    delete (cachedScore as any).content_hash
+    const client = makeMockClient(makeApiResponse({ overall_score: 60 }))
+    const sessions = {
+      'sess-1': makeSession({ content_hash: '-home-test-project:2026-01-01T00:00:00Z:2:Implement a login page' } as any),
+    }
+    const cached: Record<string, any> = { 'sess-1': cachedScore }
+
+    const { results, stats } = await scoreSessions(['sess-1'], sessions, cached, client)
+
+    expect(stats.cached).toBe(1)
+    expect(stats.scored).toBe(0)
+  })
+
+  it('uses cache when conversation has no content_hash', async () => {
+    const cachedScore = makeScoreResult({ session_id: 'sess-1', content_hash: 'some-hash', overall_score: 75 })
+    const client = makeMockClient(makeApiResponse({ overall_score: 60 }))
+    const sessions = {
+      'sess-1': makeSession(),
+    }
+    const cached: Record<string, any> = { 'sess-1': cachedScore }
+
+    const { results, stats } = await scoreSessions(['sess-1'], sessions, cached, client)
+
+    expect(stats.cached).toBe(1)
+    expect(stats.scored).toBe(0)
+  })
+
   // --- Skipping invalid sessions ---
 
   it('skips sessions not present in allSessions', async () => {

--- a/vscode-extension/test/unit/scoring.test.ts
+++ b/vscode-extension/test/unit/scoring.test.ts
@@ -292,7 +292,7 @@ describe('scoreSessions', () => {
     expect(results['sess-1'].overall_score).toBe(75)
   })
 
-  it('uses cache when cache entry has no content_hash (legacy)', async () => {
+  it('rescores when cache entry has no content_hash but conversation does (legacy)', async () => {
     const cachedScore = makeScoreResult({ session_id: 'sess-1', overall_score: 75 })
     delete (cachedScore as any).content_hash
     const client = makeMockClient(makeApiResponse({ overall_score: 60 }))
@@ -303,8 +303,9 @@ describe('scoreSessions', () => {
 
     const { results, stats } = await scoreSessions(['sess-1'], sessions, cached, client)
 
-    expect(stats.cached).toBe(1)
-    expect(stats.scored).toBe(0)
+    expect(stats.scored).toBe(1)
+    expect(stats.cached).toBe(0)
+    expect(results['sess-1'].overall_score).toBe(60)
   })
 
   it('uses cache when conversation has no content_hash', async () => {

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -785,7 +785,8 @@ async def score_conversations_endpoint(request: ScoreRequest):
         if not cache_entry and content_hash and content_hash in hash_index:
             cache_entry = cached[hash_index[content_hash]]
 
-        if cache_entry and not force and cache_entry.get("prompt_version") == SCORING_PROMPT_VERSION:
+        hash_match = not content_hash or not cache_entry or not cache_entry.get("content_hash") or cache_entry["content_hash"] == content_hash
+        if cache_entry and not force and cache_entry.get("prompt_version") == SCORING_PROMPT_VERSION and hash_match:
             results[sid] = cache_entry
             # Re-key under new ID if found via hash fallback
             if sid not in cached:

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -785,7 +785,7 @@ async def score_conversations_endpoint(request: ScoreRequest):
         if not cache_entry and content_hash and content_hash in hash_index:
             cache_entry = cached[hash_index[content_hash]]
 
-        hash_match = not content_hash or not cache_entry or not cache_entry.get("content_hash") or cache_entry["content_hash"] == content_hash
+        hash_match = not content_hash or (cache_entry is not None and cache_entry.get("content_hash") == content_hash)
         if cache_entry and not force and cache_entry.get("prompt_version") == SCORING_PROMPT_VERSION and hash_match:
             results[sid] = cache_entry
             # Re-key under new ID if found via hash fallback

--- a/webapp/tests/test_api.py
+++ b/webapp/tests/test_api.py
@@ -294,6 +294,40 @@ class TestPostScore:
         # Should NOT have called the API since score was cached
         mock_anthropic.messages.create.assert_not_called()
 
+    def test_invalidates_cache_when_content_hash_changes(self, client, tmp_path, monkeypatch, mock_anthropic):
+        """Stale cache should be invalidated when conversation grows (content_hash changes)."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(exist_ok=True)
+        monkeypatch.setattr(main, "DATA_DIR", data_dir)
+
+        cached_score = {
+            "session_id": "sess-1",
+            "fluency_behaviors": {b: True for b in main.BEHAVIORS},
+            "overall_score": 80,
+            "coding_pattern": "conceptual_inquiry",
+            "prompt_version": main.SCORING_PROMPT_VERSION,
+            "content_hash": "proj:2026-01-01T00:00:00Z:2:hello",
+        }
+        (data_dir / "scores.json").write_text(json.dumps({"sess-1": cached_score}))
+
+        conversations = [
+            {
+                "id": "sess-1",
+                "project": "test",
+                "user_prompts": ["hello", "world", "new prompt"],
+                "started_at": "2026-01-01T00:00:00Z",
+                "content_hash": "proj:2026-01-01T00:00:00Z:3:hello",
+            },
+        ]
+        monkeypatch.setattr(main, "_resolve_data_dir", lambda data_path=None: tmp_path / "sess_dir")
+        monkeypatch.setattr(main, "get_all_conversations", lambda *a, **kw: {"conversations": conversations, "metadata": {}})
+        (tmp_path / "sess_dir").mkdir()
+
+        resp = client.post("/api/score", json={"session_ids": ["sess-1"]})
+        assert resp.status_code == 200
+        # Should have called the API since content_hash changed
+        mock_anthropic.messages.create.assert_called()
+
     def test_score_history_scoped_to_project(self, client, tmp_path, monkeypatch, mock_anthropic):
         """POST /api/score should scope score_history to the requested project."""
         data_dir = tmp_path / "data"


### PR DESCRIPTION
## Summary

- Fix stale score cache for active conversations — when a conversation grows (more prompts added), the cached score is now invalidated and rescored instead of returning stale results
- Add `content_hash` comparison to the cache validity check in both TypeScript and Python scoring paths
- If a conversation has a `content_hash`, the cache entry must have a matching one — legacy entries without hashes are rescored and backfilled

Fixes #228

## What changed

The cache validity check in `scoreConversations` only verified `prompt_version` but never compared the cached `content_hash` against the current conversation's `content_hash`. Since `content_hash` includes `promptCount`, it changes when prompts are added — but the comparison was never made. The direct ID lookup would succeed and return the stale score.

Additionally, the initial fix was too lenient — legacy cache entries without `content_hash` were passing validation via graceful degradation. Tightened to require a matching hash whenever the conversation provides one.

**Fix:** `hashMatch` condition in both codebases:
- `vscode-extension/src/scoring.ts` (line 330)
- `webapp/main.py` (line 788)

## Test plan

- [x] 4 new TypeScript tests: hash mismatch invalidation, hash match cache hit, legacy entry rescored, conversation without hash
- [x] 1 new Python test: stale cache invalidated when content_hash changes via API endpoint
- [x] All 924 TS tests pass
- [x] All 760 Python tests pass
- [x] Manual: install extension, run analysis, add prompts in Claude Code, run analysis again — score updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)