### PR TITLE
fix: deduplicate assistant messages per API turn in JSONL parser

### DIFF
--- a/.claude/specs/decisions.md
+++ b/.claude/specs/decisions.md
@@ -59,3 +59,39 @@
 **Rationale:** The metadata provides enough data for meaningful agent analytics without needing Agent SDK internal traces: cost per invocation, efficiency (tokens per tool use), duration trends, and agent continuity tracking. This is low incremental effort (regex parse of a known format) with high analytical value.
 
 **Impact:** #239 scope grows slightly (metadata parsing), but delivers significantly richer agent metrics. No dependency changes — still v1.3 milestone alongside #238.
+
+## 2026-04-15: Subagent JSONL Trace Discovery — Roadmap Impact
+
+**Context:** Full subagent session traces discovered at `~/.claude/projects/<project>/<session-uuid>/subagents/agent-<id>.jsonl` (350 files, all with `isSidechain: true`). Previously believed to be hidden/inaccessible. Contains complete tool_use/tool_result sequences with `is_error` flags, per-step token usage, and internal reasoning.
+
+### Decision 6: Subagent trace analysis goes to v1.3, not v1.2
+
+**Options considered:**
+- A) Expand v1.2 scope to include subagent trace parsing
+- B) Keep v1.2 focused on main conversation quality; add subagent traces to v1.3
+
+**Decision:** Option B (v1.3)
+
+**Rationale:** v1.2 is already in progress with a well-defined scope (scoring prompt v2.0, error recovery for main sessions, verification, learning trajectory, task-type normalization). Adding subagent parsing would expand scope significantly and create a new dependency chain (#254 -> #255 -> #256). The subagent parser (#255) also depends on #254 (token counting fix) which needs its own resolution first.
+
+**Impact:** Two new issues created for v1.3: #255 (subagent JSONL parser) and #256 (subagent error recovery). v1.2 error recovery (#245) targets main conversation flow only. v1.3 gains a coherent subagent analytics track: #254 -> #255 -> #256, enriching #239 and #240.
+
+### Decision 7: "Subagent awareness" removed from Deferred Features
+
+**Context:** The Deferred Features table listed "Subagent awareness" with reason "Requires un-filtering sidechains; ambiguous attribution." The discovery of full subagent traces with `agentId` linking eliminates both blockers.
+
+**Decision:** Remove from deferred list. Track as active v1.3 work via #255 and #256.
+
+**Rationale:** The original deferral reasons no longer apply: (1) subagent JSONL files are separate from main session files, so no un-filtering needed; (2) `agentId` field on all messages provides unambiguous attribution back to parent session invocations.
+
+**Impact:** Roadmap deferred features table updated. New dependency chain added to dependency graph.
+
+### Decision 8: AgentFluent trigger shifts from data availability to audience divergence
+
+**Context:** The AgentFluent bootstrap strategy previously assumed data availability (hidden internal traces) was the trigger for a separate product. Full subagent traces eliminate this barrier.
+
+**Decision:** The trigger for AgentFluent as a separate product is now **audience divergence** — when CodeFluent needs to serve Agent SDK/production users with fundamentally different workflows (CI/CD integration, programmatic prompt versioning, batch analysis) that don't fit the interactive focus.
+
+**Rationale:** All features previously thought to require Agent SDK (prompt-to-behavior correlation, detailed error analysis, internal reasoning analysis) are available from existing Claude Code subagent data. The remaining Agent SDK-only needs (programmatic prompt version management, CI/CD hooks, custom instrumentation) serve a different user persona than CodeFluent's interactive Claude Code users.
+
+**Impact:** No immediate product change. CodeFluent absorbs more agent analytics than originally planned (v1.3 subagent traces). AgentFluent becomes a product decision driven by market signal, not a technical necessity driven by data gaps. Bootstrap strategy updated in `docs/AGENT_ANALYTICS_RESEARCH.md`.

--- a/docs/AGENT_ANALYTICS_RESEARCH.md
+++ b/docs/AGENT_ANALYTICS_RESEARCH.md
@@ -315,32 +315,44 @@ The positioning would be: **"The tools that exist tell you what your agent did. 
 
 ### How Subagent Data Appears in JSONL
 
-Subagent activity is **inlined into the parent session file** — no separate JSONL files are created. When Claude spawns a subagent, the sequence in the parent session is:
+Subagent data exists in **two locations**:
 
+**1. Parent session (summary only):**
+When Claude spawns a subagent, the parent session contains:
 1. Assistant message with `tool_use` block where `name: "Agent"` and `input` contains `subagent_type`, `description`, and `prompt`
-2. The subagent runs in its own isolated context (not visible in the parent JSONL)
-3. A `tool_result` block returns only the subagent's final summary to the parent session
+2. A `tool_result` block with the subagent's final summary + metadata (`total_tokens`, `tool_uses`, `duration_ms`, `agentId`)
 
-The `isSidechain` flag exists in the schema but is not set to `true` for any observed session files. All 14 JSONL files in the codefluent project are primary sessions.
+**2. Separate subagent JSONL files (full internal traces):**
+Each subagent session is written to `~/.claude/projects/<project>/<session-uuid>/subagents/agent-<agentId>.jsonl`. These files contain **complete session data** — user prompts, assistant responses with token usage, tool_use/tool_result pairs, and all internal reasoning steps. All messages have `isSidechain: true`.
 
-### Observable vs Hidden Data
+**Updated 2026-04-15:** Earlier analysis incorrectly stated "no separate JSONL files are created." In fact, 350 subagent files were found across projects, containing full traces. The original analysis only examined top-level JSONL files and missed the `<session-uuid>/subagents/` subdirectory structure.
 
-**Updated 2026-04-14** based on analysis of actual custom PM agent invocations. The metadata block on `tool_result` provides significantly more data than initially expected.
+### Data Availability
 
-| Data Point | Visible in Parent JSONL | Hidden (Subagent Internal) |
+| Data Point | Parent JSONL (summary) | Subagent JSONL (full trace) |
 |---|---|---|
-| Which agent was invoked | Yes (`subagent_type` field) | — |
-| Delegation prompt | Yes (`prompt` in Agent tool input) | — |
+| Which agent was invoked | Yes (`subagent_type` field) | Yes (`agentId` on all messages) |
+| Delegation prompt | Yes (`prompt` in Agent tool input) | Yes (first user message) |
 | Agent description | Yes (`description` field) | — |
-| Final result/summary | Yes (`tool_result` content) | — |
-| Total tokens per invocation | **Yes** (metadata `total_tokens`) | Per-tool-call breakdown |
-| Tool use count per invocation | **Yes** (metadata `tool_uses`) | Which specific tools were called |
-| Duration per invocation | **Yes** (metadata `duration_ms`) | Per-step timing |
-| Agent session ID | **Yes** (metadata `agentId`) | — |
-| Agent self-reported issues | **Yes** (extractable from output text) | Internal error details |
-| Internal tool calls | No | Yes (Read, Grep, Bash, etc.) |
-| Internal reasoning steps | No | Yes |
-| Retries and errors (internal) | No | Yes |
+| Final result/summary | Yes (`tool_result` content) | Yes (last assistant message) |
+| Total tokens per invocation | Yes (metadata `total_tokens`) | Yes (sum of assistant usage) |
+| Tool use count per invocation | Yes (metadata `tool_uses`) | Yes (individual tool_use blocks) |
+| Duration per invocation | Yes (metadata `duration_ms`) | Yes (timestamp span) |
+| Agent session ID | Yes (metadata `agentId`) | Yes (`agentId` field) |
+| **Internal tool calls** | **No** | **Yes** — Read (348), Bash (230), Grep (100), Edit (71), etc. |
+| **Internal tool results** | **No** | **Yes** — including `is_error`, exit codes, error content |
+| **Internal reasoning steps** | **No** | **Yes** — full assistant response content |
+| **Retries and errors** | **No** | **Yes** — tool_result with `is_error: true` |
+| **Per-step token usage** | **No** | **Yes** — usage on each assistant message |
+
+### Implications
+
+This discovery significantly upgrades the feasibility of agent analytics:
+
+1. **Error recovery analysis extends to subagents.** The same error-recovery detection (#245) can be applied to subagent sessions — we have full tool_use/tool_result sequences with error flags.
+2. **Prompt-to-behavior correlation is possible without Agent SDK.** The subagent's delegation prompt (from parent) + full internal traces (from subagent file) provide the complete picture. This was previously thought to require Agent SDK migration.
+3. **Token attribution is precise.** Per-step token usage in subagent files enables exact cost attribution per agent invocation, not just the summary `total_tokens` from metadata.
+4. **AgentFluent's "hidden data" requirement is eliminated.** The key features listed as "requires Agent SDK data" (prompt-to-behavior correlation, detailed error analysis, internal reasoning) are all available in subagent JSONL files.
 
 ### Observed Subagent Usage Patterns (CodeFluent Project)
 
@@ -392,31 +404,37 @@ These fields enable per-agent analytics cards without any Agent SDK migration:
 
 ### Implications for AgentFluent Prototype
 
-**What's testable with subagent data (more than initially expected):**
+**Updated 2026-04-15:** The discovery of full subagent JSONL traces eliminates the previously assumed data barrier. All features listed below are now feasible with Claude Code subagent data alone.
+
+**Fully available from subagent JSONL files:**
 - Invocation frequency and patterns — which agents are used, how often, for what tasks
 - Delegation effectiveness — is the agent description triggering appropriate delegation?
 - Output quality — does the returned summary lead to course-corrections by the user?
 - Configuration quality — tool restrictions, model selection, description clarity
-- **Cost attribution per agent invocation** — `total_tokens` from metadata
-- **Efficiency metrics** — tokens per tool use, duration per tool use
-- **Failure detection** — self-reported issues extractable from output text
-- **Agent continuity patterns** — fresh spawn vs SendMessage continuation
+- Cost attribution per agent invocation — per-step token usage from assistant messages
+- Efficiency metrics — tokens per tool use, duration per tool use
+- Failure detection — `is_error: true` on tool_result blocks, error content extraction
+- Agent continuity patterns — fresh spawn vs SendMessage continuation
+- **Prompt-to-behavior correlation** — delegation prompt (parent) + full internal traces (subagent file) provide the complete picture
+- **Detailed error analysis** — which tool failed, what the error was, how many retries — all in tool_result blocks
+- **Internal reasoning analysis** — full assistant response content available
+- **Error recovery patterns** — same detection algorithm as #245 applies to subagent sessions
 
-**What still requires Agent SDK data (AgentFluent-specific features):**
-- Prompt-to-behavior correlation — connecting system prompt phrasing to *specific* internal tool errors, retries, and stuck patterns (need per-tool-call traces)
-- Detailed error analysis — which tool failed, what the error was, how many retries
-- Prompt regression detection — comparing internal behavior across prompt versions
-- Internal reasoning analysis — did the agent follow its instructions or drift?
+**What genuinely requires Agent SDK (production agent use case only):**
+- Programmatic prompt version management — hardcoded prompts in application code vs interactive prompts
+- CI/CD integration — automated agent runs without a human in the loop
+- Custom instrumentation hooks — programmatic callbacks vs shell command hooks
 
 ### Bootstrap Strategy
 
-**Updated 2026-04-14:** The metadata block discovery makes subagent data more useful than initially expected. Custom Claude Code subagents provide enough data for meaningful agent analytics — not just configuration quality, but cost tracking, efficiency metrics, failure detection, and continuity analysis.
+**Updated 2026-04-15:** The discovery of full subagent JSONL traces fundamentally changes the bootstrap path. The question "why did my agent make 22 tool calls?" **can** be answered from subagent JSONL files — no Agent SDK migration needed. The trigger for AgentFluent shifts from "data availability" to "audience divergence" (interactive users vs production agent developers).
 
 1. **Done:** Deploy custom PM agent for real work in Claude Code. First invocations produced actionable data (April 14).
-2. **CodeFluent v1.2:** Capture metadata block in agent invocation tracking (#239) — `total_tokens`, `tool_uses`, `duration_ms`, `agentId`
-3. **CodeFluent v1.3:** Agent config scanning (#238), agent-aware recommendations (#240), agent advisor (#241)
-4. **When the gap hurts:** If lack of internal visibility (per-tool-call traces) becomes a blocker for optimizing subagent prompts, rebuild key agents using the Agent SDK to get full traces — that's the trigger for an AgentFluent prototype
-5. **AgentFluent signal:** The trigger is when you find yourself asking "why did my agent make 22 tool calls?" and the metadata alone can't answer it. That's when per-tool-call traces from the Agent SDK become essential.
+2. **Done:** Discovered full subagent traces in `<session-uuid>/subagents/agent-<id>.jsonl` — eliminates the "hidden data" barrier (April 15).
+3. **CodeFluent v1.1.1:** Fix subagent token counting (#254) — include sidechain token usage in totals
+4. **CodeFluent v1.2:** Capture metadata block in agent invocation tracking (#239) — `total_tokens`, `tool_uses`, `duration_ms`, `agentId`
+5. **CodeFluent v1.3:** Agent config scanning (#238), agent-aware recommendations (#240), parse subagent JSONL files for detailed agent analytics (error recovery, tool patterns, efficiency)
+6. **AgentFluent trigger:** Not data availability (solved), but audience divergence — when the product needs to serve Agent SDK/production users with different workflows (CI/CD integration, programmatic prompt versioning, batch analysis) that don't fit CodeFluent's interactive focus
 
 ---
 

--- a/docs/RELEASE_ROADMAP.md
+++ b/docs/RELEASE_ROADMAP.md
@@ -122,6 +122,7 @@ Features from different research docs that describe the same underlying capabili
   - Heuristic: detect error/failure states in conversation flow
   - Recovery strategy diversity scoring
   - `failure_to_resolution_turns` metric
+  - **v1.3 extension:** Apply same detection to subagent sessions (#256) — subagent error recovery reflects agent prompt quality rather than human fluency
 - **Verification behavior detection**
   - Tool sequence analysis: Read/Grep after Edit, Bash test commands before commit
   - `test_before_commit_rate`, `review_before_accept_rate`
@@ -151,6 +152,7 @@ Features from different research docs that describe the same underlying capabili
 - **Agentic pattern detection** (deeper than Epic 1)
   - Tool orchestration patterns (Read before Edit, Grep before Write)
   - Session management detection (--resume, fork_session)
+  - **Subagent trace analysis** (#255) — parse full subagent JSONL files for per-tool-type breakdown, error rates, per-step token usage, and retry patterns. Enables precise cost attribution and agent efficiency scoring for the Agentic Architecture radar axis.
 - **Context efficiency scoring**
   - Token growth rate per turn (bloat detection)
   - `/compact` usage detection (parser enhancement #160)
@@ -217,9 +219,9 @@ Features from different research docs that describe the same underlying capabili
 | Epic | Scope | Size |
 |------|-------|------|
 | Epic 2: Task Classification | Phase B (LLM layer) | M |
-| Epic 4: Interaction Quality Metrics | Full | L |
+| Epic 4: Interaction Quality Metrics | Full (main session only) | L |
 
-**Key properties:** First scoring prompt change (v1.0 → v2.0). Bundles all prompt-dependent features. LLM task classification enables normalization of Epic 1 metrics.
+**Key properties:** First scoring prompt change (v1.0 → v2.0). Bundles all prompt-dependent features. LLM task classification enables normalization of Epic 1 metrics. Error recovery (#245) targets main conversation flow — subagent extension deferred to v1.3.
 
 ### v1.3 — "Mastery"
 
@@ -227,8 +229,9 @@ Features from different research docs that describe the same underlying capabili
 |------|-------|------|
 | Epic 5: CCA Scoring Dimensions | Full | XL |
 | Epic 6: Scoring Quality | Full | L |
+| Agent trace analytics | Subagent JSONL parser (#255), subagent error recovery (#256), agent config scanning (#238), agent invocation tracking (#239), agent recommendations (#240) | L |
 
-**Key properties:** Establishes multi-dimensional scoring. Parser enhancement unlocks /compact and hook data. Scoring quality improvements after dimensions stabilize.
+**Key properties:** Establishes multi-dimensional scoring. Parser enhancement unlocks /compact and hook data. Scoring quality improvements after dimensions stabilize. Subagent trace parsing (#255) enables precise agent cost attribution and feeds the Agentic Architecture radar axis.
 
 ### v2.0 — "Outcomes"
 
@@ -254,6 +257,11 @@ Epic 2a (Heuristic Classification) ──→ Epic 2b (LLM) ──→ Epic 4 (Int
                                             │
                                             v
                                      Epic 7 (Outcomes)
+
+#254 (subagent token fix) ──→ #255 (subagent parser) ──→ #256 (subagent error recovery)
+                                       │
+                                       ├──→ #239 (enriched agent metrics)
+                                       └──→ #240 (trace-based recommendations)
 ```
 
 ---
@@ -266,7 +274,7 @@ Epic 2a (Heuristic Classification) ──→ Epic 2b (LLM) ──→ Epic 4 (Int
 | Bug fix correlation | NEW_METRICS | Deep git analysis; requires months of history |
 | Code churn | NEW_METRICS | Ambiguous signal (healthy iteration vs poor quality) |
 | Model selection scoring | NEW_METRICS + CCA | Subscription-tier confound; high gaming risk |
-| Subagent awareness | NEW_METRICS | Requires un-filtering sidechains; ambiguous attribution |
+| ~~Subagent awareness~~ | NEW_METRICS | **UNBLOCKED** — full subagent JSONL traces discovered (2026-04-15). Tracked as #255, #256 in v1.3. |
 | Context bridging | NEW_METRICS | High-effort cross-conversation analysis |
 | Temporal pattern scoring | NEW_METRICS | Personal/lifestyle factors; insight-only, not scored |
 | Interactive CCA practice mode | CCA | Different interaction paradigm entirely |
@@ -307,17 +315,29 @@ Epic 2a (Heuristic Classification) ──→ Epic 2b (LLM) ──→ Epic 4 (Int
 | #172 | Configuration maturity display and scoring UI | Epic 3 | v1.1 | ✅ |
 | #206 | Track custom command and skill usage | Epic 1 | v1.1 | ✅ |
 | #210 | MCP scanner project-level mcpServers | Epic 3 | v1.1 | ✅ |
-| #217 | Handle complex skills with context:fork | Backlog | — | Open |
-| #218 | Command adoption rate metric | Backlog | — | Open |
-| #219 | Incorporate command/skill usage into scoring | Backlog | — | Open |
+| #217 | Handle complex skills with context:fork | Backlog | — | ✅ (no changes needed) |
+| #218 | Command adoption rate metric | Backlog | v1.2 | Open |
+| #219 | Incorporate command/skill usage into scoring | Backlog | v1.2 | Open |
 | #128 | Review scoring prompt definitions | Epic 4 | v1.2 | Open |
 | #101 | Behavior-token breakdown | Epic 4 | v1.2 | Open |
+| #245 | Error recovery pattern detection | Epic 4 | v1.2 | PR #249 |
+| #246 | Verification behavior detection | Epic 4 | v1.2 | Open |
+| #247 | Learning trajectory metric | Epic 4 | v1.2 | Open |
+| #248 | Task-type normalization | Epic 4 | v1.2 | Open |
+| #251 | Usage tab project scoping (ccusage removal) | Bug fix | v1.2 | Open |
+| #238 | Scan .claude/agents/ for subagent definitions | Epic 5 | v1.3 | Open |
+| #239 | Track subagent invocations | Epic 4/5 | v1.3 | Open |
+| #240 | Agent-aware recommendations | Epic 4/5 | v1.3 | Open |
+| #254 | Include subagent token usage in totals | Bug fix | v1.1.1 | Open |
+| #255 | Parse subagent JSONL trace files | Epic 4/5 | v1.3 | Open |
+| #256 | Extend error recovery to subagent sessions | Epic 4/5 | v1.3 | Open |
 | #160 | Parser enhancement (progress messages) | Epic 5 | v1.3 | Open |
 | #112 | Multi-provider eval framework | Epic 6 | v1.3 | Open |
 | #113 | Human review loop | Epic 6 | v1.3 | Open |
 | #114 | Cross-model agreement | Epic 6 | v1.3 | Open |
 | #115 | Confidence calibration | Epic 6 | v1.3 | Open |
 | #116 | User feedback signal | Epic 6 | v1.3 | Open |
+| #241 | Agent advisor (LLM-powered) | Epic 5 | v2.0 | Open |
 
 ---
 
@@ -326,3 +346,4 @@ Epic 2a (Heuristic Classification) ──→ Epic 2b (LLM) ──→ Epic 4 (Int
 - [NEW_METRICS_RESEARCH.md](./NEW_METRICS_RESEARCH.md) — Full analysis of agent behavior, GitHub outcome, and novel scoring metrics
 - [TASK_CLASSIFICATION_RESEARCH.md](./TASK_CLASSIFICATION_RESEARCH.md) — Task classification taxonomy, tooling landscape, validation strategy
 - [CCA_FEATURE_RESEARCH.md](./CCA_FEATURE_RESEARCH.md) — CCA-F exam analysis, 14 features, three-category scoring expansion
+- [AGENT_ANALYTICS_RESEARCH.md](./AGENT_ANALYTICS_RESEARCH.md) — Agent SDK monitoring opportunity, subagent data availability, AgentFluent product concept

--- a/vscode-extension/src/parser.ts
+++ b/vscode-extension/src/parser.ts
@@ -167,6 +167,23 @@ export function parseSessionFile(filepath: string): ParsedSession | null {
   let totalCacheCreationTokens = 0
   let totalCacheReadTokens = 0
 
+  // Deduplication: Claude Code emits multiple assistant messages per API turn
+  // (streaming chunks). Each carries the same input/cache tokens but incrementing
+  // output tokens. We keep only the last message per turn to avoid over-counting.
+  let pendingTurnUsage: { input: number; output: number; cacheCreate: number; cacheRead: number } | null = null
+  let pendingTurnSig = '' // signature: "input:cacheCreate:cacheRead"
+
+  function flushPendingTurn(): void {
+    if (pendingTurnUsage) {
+      totalInputTokens += pendingTurnUsage.input
+      totalOutputTokens += pendingTurnUsage.output
+      totalCacheCreationTokens += pendingTurnUsage.cacheCreate
+      totalCacheReadTokens += pendingTurnUsage.cacheRead
+      pendingTurnUsage = null
+      pendingTurnSig = ''
+    }
+  }
+
   for (const msg of lines) {
     const msgType = msg.type || ''
 
@@ -181,6 +198,7 @@ export function parseSessionFile(filepath: string): ParsedSession | null {
     if (msg.timestamp) timestamps.push(msg.timestamp)
 
     if (msgType === 'user') {
+      flushPendingTurn()
       const content = msg.message?.content ?? ''
       const text = extractUserText(content)
       if (isSlashCommand(text)) {
@@ -197,15 +215,26 @@ export function parseSessionFile(filepath: string): ParsedSession | null {
       }
       if (msg.planContent) usedPlanMode = true
     } else if (msgType === 'assistant') {
-      assistantMsgCount++
       const msgModel = msg.message?.model
       if (msgModel && !model) model = msgModel
       const usage = msg.message?.usage
       if (usage) {
-        totalInputTokens += usage.input_tokens || 0
-        totalOutputTokens += usage.output_tokens || 0
-        totalCacheCreationTokens += usage.cache_creation_input_tokens || 0
-        totalCacheReadTokens += usage.cache_read_input_tokens || 0
+        const sig = `${usage.input_tokens || 0}:${usage.cache_creation_input_tokens || 0}:${usage.cache_read_input_tokens || 0}`
+        if (sig !== pendingTurnSig) {
+          flushPendingTurn()
+          assistantMsgCount++
+        }
+        // Always overwrite — last message in the turn has final output_tokens
+        pendingTurnUsage = {
+          input: usage.input_tokens || 0,
+          output: usage.output_tokens || 0,
+          cacheCreate: usage.cache_creation_input_tokens || 0,
+          cacheRead: usage.cache_read_input_tokens || 0,
+        }
+        pendingTurnSig = sig
+      } else {
+        flushPendingTurn()
+        assistantMsgCount++
       }
       const content = msg.message?.content
       if (Array.isArray(content)) {
@@ -217,6 +246,7 @@ export function parseSessionFile(filepath: string): ParsedSession | null {
         }
       }
     } else if (msgType === 'tool_use') {
+      flushPendingTurn()
       toolUseCount++
       let name = msg.name || msg.message?.name
       if (!name) {
@@ -232,9 +262,11 @@ export function parseSessionFile(filepath: string): ParsedSession | null {
       }
       if (name) toolsUsed.add(name)
     } else if (msgType === 'thinking') {
+      flushPendingTurn()
       thinkingCount++
     }
   }
+  flushPendingTurn()
 
   if (isSidechain) return null
   if (userPrompts.length === 0) return null
@@ -315,6 +347,18 @@ export function parseSessionMessages(filepath: string): SessionMessagesResult | 
 
   const messages: TimestampedMessage[] = []
 
+  // Deduplication: buffer the last assistant message per turn, emit on turn boundary.
+  let pendingAssistant: TimestampedMessage | null = null
+  let pendingAssistantSig = ''
+
+  function flushPendingAssistant(): void {
+    if (pendingAssistant) {
+      messages.push(pendingAssistant)
+      pendingAssistant = null
+      pendingAssistantSig = ''
+    }
+  }
+
   for (let i = 0; i < lines.length; i++) {
     const msg = lines[i]
     const msgType = msg.type || ''
@@ -328,6 +372,7 @@ export function parseSessionMessages(filepath: string): SessionMessagesResult | 
     if (msg.isSidechain === true) isSidechain = true
 
     if (msgType === 'user') {
+      flushPendingAssistant()
       const content = msg.message?.content ?? ''
       const text = extractUserText(content)
       const isInterrupted = text === '[Request interrupted by user for tool use]'
@@ -375,9 +420,31 @@ export function parseSessionMessages(filepath: string): SessionMessagesResult | 
           cache_creation_input_tokens: usage.cache_creation_input_tokens || 0,
           cache_read_input_tokens: usage.cache_read_input_tokens || 0,
         }
+        const sig = `${usage.input_tokens || 0}:${usage.cache_creation_input_tokens || 0}:${usage.cache_read_input_tokens || 0}`
+        if (sig !== pendingAssistantSig) {
+          flushPendingAssistant()
+        }
+        // Merge tool_names from streaming chunks into the pending message
+        if (pendingAssistant && extracted.tool_names) {
+          const existing = pendingAssistant.tool_names || []
+          pendingAssistant.tool_names = [...existing, ...extracted.tool_names]
+        }
+        // Overwrite pending — last chunk has final output_tokens
+        if (pendingAssistant) {
+          pendingAssistant.usage = extracted.usage
+          pendingAssistant.timestamp = extracted.timestamp
+          pendingAssistant.file_position = extracted.file_position
+          if (extracted.model) pendingAssistant.model = extracted.model
+        } else {
+          pendingAssistant = extracted
+        }
+        pendingAssistantSig = sig
+      } else {
+        flushPendingAssistant()
+        messages.push(extracted)
       }
-      messages.push(extracted)
     } else if (msgType === 'tool_use') {
+      flushPendingAssistant()
       let name = msg.name || msg.message?.name
       if (!name) {
         const content = msg.message?.content
@@ -398,6 +465,7 @@ export function parseSessionMessages(filepath: string): SessionMessagesResult | 
         tool_names: name ? [name] : undefined,
       })
     } else if (msgType === 'thinking') {
+      flushPendingAssistant()
       messages.push({
         type: 'thinking',
         timestamp: msg.timestamp || null,
@@ -406,6 +474,7 @@ export function parseSessionMessages(filepath: string): SessionMessagesResult | 
       })
     }
   }
+  flushPendingAssistant()
 
   if (isSidechain) return null
 

--- a/webapp/extract_prompts.py
+++ b/webapp/extract_prompts.py
@@ -130,6 +130,17 @@ def parse_session_messages(filepath: Path) -> dict | None:
 
     messages = []
 
+    # Deduplication: buffer the last assistant message per turn, emit on turn boundary.
+    pending_assistant: dict | None = None
+    pending_assistant_sig = ""
+
+    def flush_pending_assistant():
+        nonlocal pending_assistant, pending_assistant_sig
+        if pending_assistant:
+            messages.append(pending_assistant)
+            pending_assistant = None
+            pending_assistant_sig = ""
+
     for i, msg in enumerate(lines):
         msg_type = msg.get("type", "")
 
@@ -148,6 +159,7 @@ def parse_session_messages(filepath: Path) -> dict | None:
             is_sidechain = True
 
         if msg_type == "user":
+            flush_pending_assistant()
             content = msg.get("message", {}).get("content", "")
             text = extract_user_text(content)
             is_interrupted = text == "[Request interrupted by user for tool use]"
@@ -194,9 +206,29 @@ def parse_session_messages(filepath: Path) -> dict | None:
                     "cache_creation_input_tokens": usage.get("cache_creation_input_tokens", 0),
                     "cache_read_input_tokens": usage.get("cache_read_input_tokens", 0),
                 }
-            messages.append(extracted)
+                sig = f"{usage.get('input_tokens', 0)}:{usage.get('cache_creation_input_tokens', 0)}:{usage.get('cache_read_input_tokens', 0)}"
+                if sig != pending_assistant_sig:
+                    flush_pending_assistant()
+                # Merge tool_names from streaming chunks
+                if pending_assistant and extracted.get("tool_names"):
+                    existing = pending_assistant.get("tool_names") or []
+                    pending_assistant["tool_names"] = existing + extracted["tool_names"]
+                # Overwrite pending — last chunk has final output_tokens
+                if pending_assistant:
+                    pending_assistant["usage"] = extracted["usage"]
+                    pending_assistant["timestamp"] = extracted["timestamp"]
+                    pending_assistant["file_position"] = extracted["file_position"]
+                    if extracted.get("model"):
+                        pending_assistant["model"] = extracted["model"]
+                else:
+                    pending_assistant = extracted
+                pending_assistant_sig = sig
+            else:
+                flush_pending_assistant()
+                messages.append(extracted)
 
         elif msg_type == "tool_use":
+            flush_pending_assistant()
             name = msg.get("name") or msg.get("message", {}).get("name")
             if not name:
                 content = msg.get("message", {}).get("content", [])
@@ -214,12 +246,15 @@ def parse_session_messages(filepath: Path) -> dict | None:
             })
 
         elif msg_type == "thinking":
+            flush_pending_assistant()
             messages.append({
                 "type": "thinking",
                 "timestamp": msg.get("timestamp"),
                 "session_id": "",
                 "file_position": i,
             })
+
+    flush_pending_assistant()
 
     if is_sidechain:
         return None
@@ -281,6 +316,24 @@ def parse_session_file(filepath: Path) -> dict | None:
     total_cache_creation_tokens = 0
     total_cache_read_tokens = 0
 
+    # Deduplication: Claude Code emits multiple assistant messages per API turn
+    # (streaming chunks). Each carries the same input/cache tokens but incrementing
+    # output tokens. We keep only the last message per turn to avoid over-counting.
+    pending_turn_usage: dict | None = None
+    pending_turn_sig = ""
+
+    def flush_pending_turn():
+        nonlocal total_input_tokens, total_output_tokens
+        nonlocal total_cache_creation_tokens, total_cache_read_tokens
+        nonlocal pending_turn_usage, pending_turn_sig
+        if pending_turn_usage:
+            total_input_tokens += pending_turn_usage["input"]
+            total_output_tokens += pending_turn_usage["output"]
+            total_cache_creation_tokens += pending_turn_usage["cache_create"]
+            total_cache_read_tokens += pending_turn_usage["cache_read"]
+            pending_turn_usage = None
+            pending_turn_sig = ""
+
     for msg in lines:
         msg_type = msg.get("type", "")
 
@@ -303,6 +356,7 @@ def parse_session_file(filepath: Path) -> dict | None:
             timestamps.append(timestamp)
 
         if msg_type == "user":
+            flush_pending_turn()
             content = msg.get("message", {}).get("content", "")
             text = extract_user_text(content)
             if is_slash_command(text):
@@ -319,16 +373,25 @@ def parse_session_file(filepath: Path) -> dict | None:
                 used_plan_mode = True
 
         elif msg_type == "assistant":
-            assistant_msg_count += 1
             msg_model = msg.get("message", {}).get("model")
             if msg_model and not model:
                 model = msg_model
             usage = msg.get("message", {}).get("usage", {})
             if usage:
-                total_input_tokens += usage.get("input_tokens", 0)
-                total_output_tokens += usage.get("output_tokens", 0)
-                total_cache_creation_tokens += usage.get("cache_creation_input_tokens", 0)
-                total_cache_read_tokens += usage.get("cache_read_input_tokens", 0)
+                sig = f"{usage.get('input_tokens', 0)}:{usage.get('cache_creation_input_tokens', 0)}:{usage.get('cache_read_input_tokens', 0)}"
+                if sig != pending_turn_sig:
+                    flush_pending_turn()
+                    assistant_msg_count += 1
+                pending_turn_usage = {
+                    "input": usage.get("input_tokens", 0),
+                    "output": usage.get("output_tokens", 0),
+                    "cache_create": usage.get("cache_creation_input_tokens", 0),
+                    "cache_read": usage.get("cache_read_input_tokens", 0),
+                }
+                pending_turn_sig = sig
+            else:
+                flush_pending_turn()
+                assistant_msg_count += 1
             content = msg.get("message", {}).get("content", [])
             if isinstance(content, list):
                 for block in content:
@@ -338,6 +401,7 @@ def parse_session_file(filepath: Path) -> dict | None:
                             tools_used.add(block["name"])
 
         elif msg_type == "tool_use":
+            flush_pending_turn()
             tool_use_count += 1
             name = msg.get("name") or msg.get("message", {}).get("name")
             if not name:
@@ -351,7 +415,10 @@ def parse_session_file(filepath: Path) -> dict | None:
                 tools_used.add(name)
 
         elif msg_type == "thinking":
+            flush_pending_turn()
             thinking_count += 1
+
+    flush_pending_turn()
 
     if is_sidechain:
         return None


### PR DESCRIPTION
## Summary

- Fix ~1.4x over-counting of token usage in Conversation Analytics caused by summing duplicate assistant streaming messages
- Claude Code emits multiple assistant JSONL entries per API turn (streaming chunks) with repeated input/cache tokens — parser now deduplicates by buffering per-turn and keeping only the final message
- Applied to both `parseSessionFile` (summary) and `parseSessionMessages` (message-level) in TypeScript and Python parsers
- Also includes: corrected subagent data availability in agent analytics research, updated release roadmap with v1.2/v1.3 issue map, PM decision log updates

Fixes #252

## Test plan

- [x] TypeScript: 924 tests pass (22 suites)
- [x] Python: 760 tests pass
- [x] Type-check: `tsc --noEmit` clean
- [x] ccusage comparison: deduplicated JSONL cache_read within 3% of ccusage (was 36% over before fix)
- [x] Manual: webapp `/api/conversation-analytics` returns corrected token totals
- [x] CI: all checks green (tests, webapp tests, security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)