### PR TITLE
fix: include subagent token usage in conversation totals

### DIFF
--- a/vscode-extension/src/conversation.ts
+++ b/vscode-extension/src/conversation.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
-import { TimestampedMessage, SessionMessagesResult, parseSessionMessages } from './parser'
+import { TimestampedMessage, SessionMessagesResult, parseSessionMessages, scanSubagentTokens } from './parser'
 import { classifyTask } from './taskClassification'
 import { detectStructuredOutputAntiPattern } from './antiPatterns'
 import { computeConversationErrorRecovery } from './errorRecovery'
@@ -312,6 +312,41 @@ export function getAllConversations(
   for (const { project: proj, encoded, messages } of byProject.values()) {
     const convs = buildConversations(messages, proj, encoded, gap)
     allConversations.push(...convs)
+  }
+
+  // Add subagent token usage to conversations.
+  // Subagent tokens are real API costs but excluded from behavioral metrics by the
+  // sidechain filter. We attribute them to the FIRST conversation containing each
+  // session_id to avoid double-counting when a session spans multiple conversations.
+  const claimedSessions = new Set<string>()
+  for (const entry of fs.readdirSync(claudeDir).sort()) {
+    const projectDir = path.join(claudeDir, entry)
+    try {
+      if (!fs.statSync(projectDir).isDirectory()) continue
+    } catch { continue }
+    const subagentMap = scanSubagentTokens(projectDir)
+    if (subagentMap.size === 0) continue
+    for (const conv of allConversations) {
+      for (const sid of conv.session_ids) {
+        if (claimedSessions.has(sid)) continue
+        const tokens = subagentMap.get(sid)
+        if (!tokens) continue
+        claimedSessions.add(sid)
+        conv.total_input_tokens += tokens.input_tokens
+        conv.total_output_tokens += tokens.output_tokens
+        conv.total_cache_creation_tokens += tokens.cache_creation_tokens
+        conv.total_cache_read_tokens += tokens.cache_read_tokens
+        conv.total_tokens += tokens.input_tokens + tokens.output_tokens
+          + tokens.cache_creation_tokens + tokens.cache_read_tokens
+      }
+    }
+  }
+
+  // Recompute derived fields after adding subagent tokens
+  for (const conv of allConversations) {
+    conv.tokens_per_prompt = conv.prompt_count > 0 ? conv.total_tokens / conv.prompt_count : 0
+    const denom = conv.total_cache_read_tokens + conv.total_input_tokens + conv.total_cache_creation_tokens
+    conv.cache_hit_rate = denom > 0 ? conv.total_cache_read_tokens / denom : 0
   }
 
   // Sort by started_at descending

--- a/vscode-extension/src/parser.ts
+++ b/vscode-extension/src/parser.ts
@@ -632,3 +632,126 @@ export function getAllSessions(limit?: number, project?: string, sessionDataPath
     },
   }
 }
+
+export interface SubagentTokens {
+  input_tokens: number
+  output_tokens: number
+  cache_creation_tokens: number
+  cache_read_tokens: number
+}
+
+/**
+ * Scan subagent JSONL files under a project directory for token usage.
+ * Returns a map of parent sessionId → aggregated token counts.
+ *
+ * Subagent files live at <project>/<session-uuid>/subagents/agent-<id>.jsonl
+ * and their sessionId matches the parent UUID directory name.
+ * Token deduplication (streaming chunks) is applied.
+ */
+export function scanSubagentTokens(projectDir: string): Map<string, SubagentTokens> {
+  const result = new Map<string, SubagentTokens>()
+
+  let entries: string[]
+  try {
+    entries = fs.readdirSync(projectDir)
+  } catch {
+    return result
+  }
+
+  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+
+  for (const entry of entries) {
+    if (!uuidPattern.test(entry)) continue
+    const subagentsDir = path.join(projectDir, entry, 'subagents')
+    let subFiles: string[]
+    try {
+      subFiles = fs.readdirSync(subagentsDir).filter(f => f.endsWith('.jsonl'))
+    } catch {
+      continue
+    }
+
+    for (const sf of subFiles) {
+      const filepath = path.join(subagentsDir, sf)
+      let raw: string
+      try {
+        raw = fs.readFileSync(filepath, 'utf8')
+      } catch {
+        continue
+      }
+
+      // Deduplicate assistant messages per turn (same as main parser)
+      let pendingUsage: { input: number; output: number; cacheCreate: number; cacheRead: number } | null = null
+      let pendingSig = ''
+      let sessionId: string | null = null
+      let totalInput = 0
+      let totalOutput = 0
+      let totalCacheCreate = 0
+      let totalCacheRead = 0
+
+      function flush(): void {
+        if (pendingUsage) {
+          totalInput += pendingUsage.input
+          totalOutput += pendingUsage.output
+          totalCacheCreate += pendingUsage.cacheCreate
+          totalCacheRead += pendingUsage.cacheRead
+          pendingUsage = null
+          pendingSig = ''
+        }
+      }
+
+      for (const line of raw.split('\n')) {
+        const trimmed = line.trim()
+        if (!trimmed) continue
+        let msg: any
+        try {
+          msg = JSON.parse(trimmed)
+        } catch {
+          continue
+        }
+
+        if (!sessionId && msg.sessionId) sessionId = msg.sessionId
+
+        if (msg.type === 'assistant') {
+          const usage = msg.message?.usage
+          if (usage) {
+            const sig = `${usage.input_tokens || 0}:${usage.cache_creation_input_tokens || 0}:${usage.cache_read_input_tokens || 0}`
+            if (sig !== pendingSig) flush()
+            pendingUsage = {
+              input: usage.input_tokens || 0,
+              output: usage.output_tokens || 0,
+              cacheCreate: usage.cache_creation_input_tokens || 0,
+              cacheRead: usage.cache_read_input_tokens || 0,
+            }
+            pendingSig = sig
+          } else {
+            flush()
+          }
+        } else {
+          flush()
+        }
+      }
+      flush()
+
+      if (!sessionId) sessionId = entry  // fallback to parent UUID dir name
+      const total = totalInput + totalOutput + totalCacheCreate + totalCacheRead
+      if (total === 0) continue
+
+      const existing = result.get(sessionId)
+      if (existing) {
+        existing.input_tokens += totalInput
+        existing.output_tokens += totalOutput
+        existing.cache_creation_tokens += totalCacheCreate
+        existing.cache_read_tokens += totalCacheRead
+      } else {
+        result.set(sessionId, {
+          input_tokens: totalInput,
+          output_tokens: totalOutput,
+          cache_creation_tokens: totalCacheCreate,
+          cache_read_tokens: totalCacheRead,
+        })
+      }
+    }
+  }
+
+  return result
+}

--- a/webapp/conversations.py
+++ b/webapp/conversations.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from pathlib import Path
 
-from extract_prompts import parse_session_messages, _get_project_path_encoded, _UUID_PATTERN
+from extract_prompts import parse_session_messages, _get_project_path_encoded, _UUID_PATTERN, scan_subagent_tokens
 from config import get_config
 from task_classification import classify_task
 from anti_patterns import detect_structured_output_anti_pattern
@@ -257,6 +257,40 @@ def get_all_conversations(
     for info in by_project.values():
         convs = build_conversations(info["messages"], info["project"], info["encoded"], gap_minutes)
         all_conversations.extend(convs)
+
+    # Add subagent token usage to conversations.
+    # Attribute to the FIRST conversation containing each session_id to avoid
+    # double-counting when a session spans multiple conversations.
+    claimed_sessions: set[str] = set()
+    for project_dir in sorted(data_dir.iterdir()):
+        if not project_dir.is_dir():
+            continue
+        subagent_map = scan_subagent_tokens(project_dir)
+        if not subagent_map:
+            continue
+        for conv in all_conversations:
+            for sid in conv.get("session_ids", []):
+                if sid in claimed_sessions:
+                    continue
+                tokens = subagent_map.get(sid)
+                if not tokens:
+                    continue
+                claimed_sessions.add(sid)
+                conv["total_input_tokens"] += tokens["input_tokens"]
+                conv["total_output_tokens"] += tokens["output_tokens"]
+                conv["total_cache_creation_tokens"] += tokens["cache_creation_tokens"]
+                conv["total_cache_read_tokens"] += tokens["cache_read_tokens"]
+                conv["total_tokens"] += (
+                    tokens["input_tokens"] + tokens["output_tokens"]
+                    + tokens["cache_creation_tokens"] + tokens["cache_read_tokens"]
+                )
+
+    # Recompute derived fields after adding subagent tokens
+    for conv in all_conversations:
+        pc = conv.get("prompt_count", 0)
+        conv["tokens_per_prompt"] = conv["total_tokens"] / pc if pc > 0 else 0
+        denom = conv["total_cache_read_tokens"] + conv["total_input_tokens"] + conv["total_cache_creation_tokens"]
+        conv["cache_hit_rate"] = conv["total_cache_read_tokens"] / denom if denom > 0 else 0
 
     # Sort by started_at descending
     all_conversations.sort(key=lambda c: c.get("started_at") or "", reverse=True)

--- a/webapp/extract_prompts.py
+++ b/webapp/extract_prompts.py
@@ -586,5 +586,109 @@ def main():
     print(f"Written to {output_path}")
 
 
+def scan_subagent_tokens(project_dir: Path) -> dict[str, dict]:
+    """Scan subagent JSONL files under a project directory for token usage.
+
+    Returns a dict of parent sessionId -> {input_tokens, output_tokens,
+    cache_creation_tokens, cache_read_tokens}.
+
+    Subagent files live at <project>/<session-uuid>/subagents/agent-<id>.jsonl
+    and their sessionId matches the parent UUID directory name.
+    Token deduplication (streaming chunks) is applied.
+    """
+    result: dict[str, dict] = {}
+
+    try:
+        entries = list(project_dir.iterdir())
+    except OSError:
+        return result
+
+    for entry in entries:
+        if not entry.is_dir() or not _UUID_PATTERN.match(entry.name):
+            continue
+        subagents_dir = entry / "subagents"
+        if not subagents_dir.is_dir():
+            continue
+
+        for sf in subagents_dir.iterdir():
+            if not sf.name.endswith(".jsonl"):
+                continue
+
+            session_id = None
+            total_input = 0
+            total_output = 0
+            total_cache_create = 0
+            total_cache_read = 0
+            pending_usage: dict | None = None
+            pending_sig = ""
+
+            def flush():
+                nonlocal total_input, total_output, total_cache_create, total_cache_read
+                nonlocal pending_usage, pending_sig
+                if pending_usage:
+                    total_input += pending_usage["input"]
+                    total_output += pending_usage["output"]
+                    total_cache_create += pending_usage["cache_create"]
+                    total_cache_read += pending_usage["cache_read"]
+                    pending_usage = None
+                    pending_sig = ""
+
+            try:
+                with open(sf, "r", errors="replace") as fh:
+                    for line in fh:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            msg = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+
+                        if not session_id and msg.get("sessionId"):
+                            session_id = msg["sessionId"]
+
+                        if msg.get("type") == "assistant":
+                            usage = msg.get("message", {}).get("usage", {})
+                            if usage:
+                                sig = f"{usage.get('input_tokens', 0)}:{usage.get('cache_creation_input_tokens', 0)}:{usage.get('cache_read_input_tokens', 0)}"
+                                if sig != pending_sig:
+                                    flush()
+                                pending_usage = {
+                                    "input": usage.get("input_tokens", 0),
+                                    "output": usage.get("output_tokens", 0),
+                                    "cache_create": usage.get("cache_creation_input_tokens", 0),
+                                    "cache_read": usage.get("cache_read_input_tokens", 0),
+                                }
+                                pending_sig = sig
+                            else:
+                                flush()
+                        else:
+                            flush()
+                flush()
+            except OSError:
+                continue
+
+            if not session_id:
+                session_id = entry.name
+            total = total_input + total_output + total_cache_create + total_cache_read
+            if total == 0:
+                continue
+
+            if session_id in result:
+                result[session_id]["input_tokens"] += total_input
+                result[session_id]["output_tokens"] += total_output
+                result[session_id]["cache_creation_tokens"] += total_cache_create
+                result[session_id]["cache_read_tokens"] += total_cache_read
+            else:
+                result[session_id] = {
+                    "input_tokens": total_input,
+                    "output_tokens": total_output,
+                    "cache_creation_tokens": total_cache_create,
+                    "cache_read_tokens": total_cache_read,
+                }
+
+    return result
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

- Subagent sessions (isSidechain: true) were excluded from all token counts — their API costs were invisible
- New `scanSubagentTokens()` function scans `<session-uuid>/subagents/agent-<id>.jsonl` files for token usage with streaming deduplication
- Tokens attributed to the first conversation per parent session_id (avoids double-counting when sessions span multiple conversations)
- Applied to both TypeScript and Python parsers

Fixes #254

## Key finding

ccusage **excludes** subagent tokens, so our totals will now be higher than ccusage. This is intentionally more accurate — subagent tokens represent real API cost (~617M tokens, ~33% of main session volume).

| Metric | Main only | + Subagents | ccusage |
|--------|-----------|-------------|---------|
| cache_read | 1,123M | 1,547M | 1,232M |

## Test plan

- [x] TypeScript: 942 tests pass
- [x] Python: 777 tests pass
- [x] Type-check: clean
- [x] Verified subagent tokens attributed correctly (no double-counting across conversations)
- [x] Verified streaming dedup applied to subagent files (1.41x reduction)
- [ ] Manual: webapp conversation analytics shows higher totals than before
- [ ] Manual: extension Conversation Analytics reflects subagent costs

🤖 Generated with [Claude Code](https://claude.com/claude-code)