### PR TITLE
feat: command/skill adoption rate metric card (#218)

### DIFF
--- a/vscode-extension/media/app.js
+++ b/vscode-extension/media/app.js
@@ -1809,7 +1809,8 @@ function renderAgentMetrics(metrics) {
     { title: 'Tool Diversity', value: metrics.tool_diversity_index, detail: 'unique tools / total uses', key: 'tool_diversity_index', color: '#D97706', format: 'percent' },
     { title: 'Plan Mode Adoption', value: metrics.plan_mode_adoption_rate, detail: 'conversations using plan mode', key: 'plan_mode_adoption_rate', color: '#2563EB', format: 'percent' },
     { title: 'Cache Efficiency', value: metrics.avg_cache_hit_rate, detail: 'average cache hit rate', key: 'avg_cache_hit_rate', color: '#059669', format: 'percent' },
-    { title: 'Thinking Utilization', value: metrics.thinking_utilization_rate, detail: 'responses using extended thinking', key: 'thinking_utilization_rate', color: '#7C3AED', format: 'percent' }
+    { title: 'Thinking Utilization', value: metrics.thinking_utilization_rate, detail: 'responses using extended thinking', key: 'thinking_utilization_rate', color: '#7C3AED', format: 'percent' },
+    { title: 'Command Adoption', value: metrics.command_adoption_rate, detail: 'conversations using commands/skills', key: 'command_adoption_rate', color: '#0891B2', format: 'percent' }
   ]
 
   // Add error recovery cards if data is available

--- a/vscode-extension/src/agentMetrics.ts
+++ b/vscode-extension/src/agentMetrics.ts
@@ -6,6 +6,7 @@ export interface AgentMetrics {
   plan_mode_adoption_rate: number    // conversations_with_plan / total, 0-1
   avg_cache_hit_rate: number         // mean of per-conversation cache_hit_rate, 0-1
   thinking_utilization_rate: number  // sum(thinking_count) / sum(assistant_message_count), 0-1
+  command_adoption_rate: number      // conversations_with_commands / total, 0-1
   avg_prompt_length: number          // mean character length across all user prompts
   conversation_count: number         // total conversations analyzed
 }
@@ -23,6 +24,7 @@ export interface WeeklyAgentMetrics {
   plan_mode_adoption_rate: number
   avg_cache_hit_rate: number
   thinking_utilization_rate: number
+  command_adoption_rate: number
   conversation_count: number
 }
 
@@ -53,6 +55,7 @@ export function computeAgentMetrics(conversations: ParsedConversation[]): AgentM
       plan_mode_adoption_rate: 0,
       avg_cache_hit_rate: 0,
       thinking_utilization_rate: 0,
+      command_adoption_rate: 0,
       avg_prompt_length: 0,
       conversation_count: 0,
     }
@@ -75,6 +78,10 @@ export function computeAgentMetrics(conversations: ParsedConversation[]): AgentM
   const totalAssistant = conversations.reduce((sum, c) => sum + c.assistant_message_count, 0)
   const thinkingUtilizationRate = totalAssistant > 0 ? totalThinking / totalAssistant : 0
 
+  // Command adoption: fraction of conversations using custom commands/skills
+  const commandCount = conversations.filter(c => (c.commands_used?.length ?? 0) > 0).length
+  const commandAdoptionRate = commandCount / conversations.length
+
   // Avg prompt length: mean across ALL user prompts from all conversations
   const allPrompts = conversations.flatMap(c => c.user_prompts)
   const avgPromptLength = allPrompts.length > 0
@@ -86,6 +93,7 @@ export function computeAgentMetrics(conversations: ParsedConversation[]): AgentM
     plan_mode_adoption_rate: roundRate(planModeAdoptionRate),
     avg_cache_hit_rate: roundRate(avgCacheHitRate),
     thinking_utilization_rate: roundRate(thinkingUtilizationRate),
+    command_adoption_rate: roundRate(commandAdoptionRate),
     avg_prompt_length: Math.round(avgPromptLength),
     conversation_count: conversations.length,
   }
@@ -127,6 +135,7 @@ export function computeWeeklyAgentMetrics(conversations: ParsedConversation[]): 
     const cacheSum = weekConvs.reduce((sum, c) => sum + c.cache_hit_rate, 0)
     const totalThinking = weekConvs.reduce((sum, c) => sum + c.thinking_count, 0)
     const totalAssistant = weekConvs.reduce((sum, c) => sum + c.assistant_message_count, 0)
+    const cmdCount = weekConvs.filter(c => (c.commands_used?.length ?? 0) > 0).length
 
     result.push({
       week,
@@ -134,6 +143,7 @@ export function computeWeeklyAgentMetrics(conversations: ParsedConversation[]): 
       plan_mode_adoption_rate: roundRate(planCount / n),
       avg_cache_hit_rate: roundRate(cacheSum / n),
       thinking_utilization_rate: roundRate(totalAssistant > 0 ? totalThinking / totalAssistant : 0),
+      command_adoption_rate: roundRate(cmdCount / n),
       conversation_count: n,
     })
   }

--- a/vscode-extension/test/unit/agentMetrics.test.ts
+++ b/vscode-extension/test/unit/agentMetrics.test.ts
@@ -50,6 +50,7 @@ describe('computeAgentMetrics', () => {
       plan_mode_adoption_rate: 0,
       avg_cache_hit_rate: 0,
       thinking_utilization_rate: 0,
+      command_adoption_rate: 0,
       avg_prompt_length: 0,
       conversation_count: 0,
     })

--- a/webapp/agent_metrics.py
+++ b/webapp/agent_metrics.py
@@ -45,6 +45,7 @@ def compute_agent_metrics(conversations: list[dict]) -> dict:
             "plan_mode_adoption_rate": 0,
             "avg_cache_hit_rate": 0,
             "thinking_utilization_rate": 0,
+            "command_adoption_rate": 0,
             "avg_prompt_length": 0,
             "conversation_count": 0,
         }
@@ -68,6 +69,10 @@ def compute_agent_metrics(conversations: list[dict]) -> dict:
     total_assistant = sum(c.get("assistant_message_count", 0) for c in conversations)
     thinking_utilization_rate = total_thinking / total_assistant if total_assistant > 0 else 0
 
+    # Command adoption: fraction of conversations using custom commands/skills
+    command_count = sum(1 for c in conversations if c.get("commands_used"))
+    command_adoption_rate = command_count / n
+
     # Avg prompt length: mean across ALL user prompts
     all_prompts = [p for c in conversations for p in c.get("user_prompts", [])]
     avg_prompt_length = sum(len(p) for p in all_prompts) / len(all_prompts) if all_prompts else 0
@@ -77,6 +82,7 @@ def compute_agent_metrics(conversations: list[dict]) -> dict:
         "plan_mode_adoption_rate": round(plan_mode_adoption_rate, 4),
         "avg_cache_hit_rate": round(avg_cache_hit_rate, 4),
         "thinking_utilization_rate": round(thinking_utilization_rate, 4),
+        "command_adoption_rate": round(command_adoption_rate, 4),
         "avg_prompt_length": round(avg_prompt_length),
         "conversation_count": n,
     }
@@ -119,6 +125,7 @@ def compute_weekly_agent_metrics(conversations: list[dict]) -> list[dict]:
         cache_sum = sum(c.get("cache_hit_rate", 0) for c in week_convs)
         total_thinking = sum(c.get("thinking_count", 0) for c in week_convs)
         total_assistant = sum(c.get("assistant_message_count", 0) for c in week_convs)
+        cmd_count = sum(1 for c in week_convs if c.get("commands_used"))
 
         result.append({
             "week": week_key,
@@ -126,6 +133,7 @@ def compute_weekly_agent_metrics(conversations: list[dict]) -> list[dict]:
             "plan_mode_adoption_rate": round(plan_count / n, 4),
             "avg_cache_hit_rate": round(cache_sum / n, 4),
             "thinking_utilization_rate": round(total_thinking / total_assistant, 4) if total_assistant > 0 else 0,
+            "command_adoption_rate": round(cmd_count / n, 4),
             "conversation_count": n,
         })
 

--- a/webapp/static/app.js
+++ b/webapp/static/app.js
@@ -1904,7 +1904,8 @@ function renderAgentMetrics(metrics) {
     { title: 'Tool Diversity', value: metrics.tool_diversity_index, detail: 'unique tools / total uses', key: 'tool_diversity_index', color: '#D97706', format: 'percent' },
     { title: 'Plan Mode Adoption', value: metrics.plan_mode_adoption_rate, detail: 'conversations using plan mode', key: 'plan_mode_adoption_rate', color: '#2563EB', format: 'percent' },
     { title: 'Cache Efficiency', value: metrics.avg_cache_hit_rate, detail: 'average cache hit rate', key: 'avg_cache_hit_rate', color: '#059669', format: 'percent' },
-    { title: 'Thinking Utilization', value: metrics.thinking_utilization_rate, detail: 'responses using extended thinking', key: 'thinking_utilization_rate', color: '#7C3AED', format: 'percent' }
+    { title: 'Thinking Utilization', value: metrics.thinking_utilization_rate, detail: 'responses using extended thinking', key: 'thinking_utilization_rate', color: '#7C3AED', format: 'percent' },
+    { title: 'Command Adoption', value: metrics.command_adoption_rate, detail: 'conversations using commands/skills', key: 'command_adoption_rate', color: '#0891B2', format: 'percent' }
   ]
 
   // Add error recovery cards if data is available

--- a/webapp/tests/test_agent_metrics.py
+++ b/webapp/tests/test_agent_metrics.py
@@ -51,6 +51,7 @@ class TestComputeAgentMetrics:
             "plan_mode_adoption_rate": 0,
             "avg_cache_hit_rate": 0,
             "thinking_utilization_rate": 0,
+            "command_adoption_rate": 0,
             "avg_prompt_length": 0,
             "conversation_count": 0,
         }


### PR DESCRIPTION
## Summary
- Add `command_adoption_rate` to agent metrics — percentage of conversations using custom commands/skills
- New teal card with weekly sparkline trend in Agent Metrics section
- Computed from existing `commands_used` field on `ParsedConversation`
- Both VS Code extension and webapp frontends

## Changes
- `agentMetrics.ts` / `agent_metrics.py` — new field in interfaces, aggregate + weekly compute functions
- `app.js` (both) — new card in `renderAgentMetrics` items array
- Tests updated for new field in empty-array expected output

## Test plan
- [x] VS Code extension: 942 tests passing
- [x] Webapp: 777 tests passing
- [ ] Manual: rebuild extension, verify Command Adoption card appears in Conversations tab
- [ ] Manual: start webapp, verify same card appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)