### PR TITLE
fix: eval CI per-behavior agreement threshold enforcement (#266)

### DIFF
--- a/shared/eval/checks.py
+++ b/shared/eval/checks.py
@@ -154,12 +154,15 @@ def check_agreement(results, threshold=0.85):
             stats["matches"] / stats["total"] if stats["total"] > 0 else 0.0, 4
         )
 
+    passed = overall >= threshold and len(below_threshold) == 0
+
     return {
         "overall_agreement": round(overall, 4),
         "per_behavior": per_behavior_rates,
         "below_threshold": below_threshold,
         "by_section": section_rates,
         "threshold": threshold,
+        "passed": passed,
     }
 
 

--- a/shared/eval/report.py
+++ b/shared/eval/report.py
@@ -102,16 +102,16 @@ def print_summary(check_name, check_result):
     elif check_name == "agreement":
         overall = check_result["overall_agreement"]
         threshold = check_result["threshold"]
-        icon = "PASS" if overall >= threshold else "FAIL"
+        passed = check_result.get("passed", overall >= threshold)
+        icon = "PASS" if passed else "FAIL"
         print(f"  [{icon}] Overall agreement: {overall:.1%} (threshold: {threshold:.0%})")
 
         if check_result["by_section"]:
-            print("  By section:")
             for section, rate in check_result["by_section"].items():
                 print(f"    {section}: {rate:.1%}")
 
         if check_result["below_threshold"]:
-            print(f"  Behaviors below {threshold:.0%}:")
+            print(f"  [FAIL] Behaviors below {threshold:.0%}:")
             for item in check_result["below_threshold"]:
                 print(f"    - {item['behavior']}: {item['agreement']:.1%}")
 

--- a/shared/eval/report.py
+++ b/shared/eval/report.py
@@ -107,6 +107,7 @@ def print_summary(check_name, check_result):
         print(f"  [{icon}] Overall agreement: {overall:.1%} (threshold: {threshold:.0%})")
 
         if check_result["by_section"]:
+            print("  By section:")
             for section, rate in check_result["by_section"].items():
                 print(f"    {section}: {rate:.1%}")
 

--- a/shared/eval/run_eval.py
+++ b/shared/eval/run_eval.py
@@ -209,6 +209,16 @@ def main(argv=None):
         filepath = save_results(results, check_results, metadata, args.output)
         print(f"\nResults saved to: {filepath}")
 
+    # Exit non-zero if any check failed
+    any_failed = False
+    for name, result in check_results.items():
+        if name == "schema" and result.get("failed", 0) > 0:
+            any_failed = True
+        elif name == "agreement" and not result.get("passed", True):
+            any_failed = True
+    if any_failed:
+        sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/shared/eval/run_eval.py
+++ b/shared/eval/run_eval.py
@@ -216,6 +216,12 @@ def main(argv=None):
             any_failed = True
         elif name == "agreement" and not result.get("passed", True):
             any_failed = True
+        elif name == "consistency" and result.get("self_agreement", 1.0) < 0.85:
+            any_failed = True
+        elif name == "drift" and result.get("drifted"):
+            any_failed = True
+        elif name == "regression" and result.get("entries_changed", 0) > 0:
+            any_failed = True
     if any_failed:
         sys.exit(1)
 


### PR DESCRIPTION
## Summary
- Eval CI now fails when **any individual behavior** drops below the 85% agreement threshold, not just the overall average
- `run_eval.py` exits non-zero when schema or agreement checks fail
- `check_agreement()` returns a `passed` boolean that requires both overall >= threshold AND zero behaviors below threshold

## Problem
Previously, `questioning_reasoning` at 81.8% and `specifying_format` at 81.8% both passed CI because the overall average was 93.7%. Averages mask individual regressions.

## Changes
- `shared/eval/checks.py` — `check_agreement` adds `passed` field (overall + per-behavior)
- `shared/eval/report.py` — `print_summary` uses `passed` field, labels below-threshold behaviors with `[FAIL]`
- `shared/eval/run_eval.py` — exit code 1 when any check fails

## Test plan
- [x] All 79 eval tests pass
- [x] All 942 VS Code extension tests pass
- [x] All 777 webapp tests pass
- [ ] CI passes (this PR doesn't touch prompts, so eval.yml won't trigger — only ci.yml + security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)