### PR TITLE
feat: secret-handling hooks, SECURITY.md, and docs (#270)

### DIFF
--- a/.claude/hooks/block_secret_reads.py
+++ b/.claude/hooks/block_secret_reads.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: block reads of files likely to contain credentials.
+
+Receives the PreToolUse event JSON on stdin. Denies the tool call when the
+target file path (or Bash command argument) matches known credential files:
+.env variants, shell rc files, SSH private keys, and named secrets files.
+
+Emits a JSON decision on stdout and exits 0 (the modern pattern); exit 2
++ stderr is the legacy fallback but not used here.
+
+Cross-platform: stdlib only, no shell dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import PurePath
+
+# The BLOCKED_BASENAMES set and the CREDENTIAL_TOKEN_PATTERNS list must stay in
+# sync — they express the same credential-file list in two matching contexts
+# (exact basename vs. substring-in-command-or-pattern). Update both together.
+BLOCKED_BASENAMES: frozenset[str] = frozenset(
+    {
+        ".env",
+        ".envrc",
+        "credentials",
+        "credentials.json",
+        "secrets.yaml",
+        "secrets.yml",
+        "secrets.json",
+        ".bashrc",
+        ".bash_profile",
+        ".profile",
+        ".zshrc",
+        ".zshenv",
+        ".zprofile",
+        "id_rsa",
+        "id_ed25519",
+        "id_ecdsa",
+        "id_dsa",
+    }
+)
+
+BLOCKED_SUFFIXES: frozenset[str] = frozenset({".pem"})
+
+# Used when the basename alone (e.g. "config.json") is too generic to block —
+# the entry's CodeFluent-specific location is what makes it sensitive.
+BLOCKED_PATH_SUFFIXES: frozenset[tuple[str, ...]] = frozenset(
+    {
+        ("webapp", "config.json"),
+    }
+)
+
+CREDENTIAL_TOKEN_PATTERNS: list[str] = [
+    r"\.env(\b|[._-][A-Za-z0-9_-]+)",
+    r"\.envrc\b",
+    r"credentials\.json\b",
+    r"secrets\.ya?ml\b",
+    r"secrets\.json\b",
+    r"\.bashrc\b",
+    r"\.bash_profile\b",
+    r"\.profile\b",
+    r"\.zshrc\b",
+    r"\.zshenv\b",
+    r"\.zprofile\b",
+    r"\bid_rsa\b",
+    r"\bid_ed25519\b",
+    r"\bid_ecdsa\b",
+    r"\bid_dsa\b",
+    r"\.pem\b",
+]
+CREDENTIAL_TOKEN_PATTERNS.extend(
+    r"\b" + r"[/\\]".join(re.escape(part) for part in suffix) + r"\b"
+    for suffix in BLOCKED_PATH_SUFFIXES
+)
+CREDENTIAL_TOKEN_REGEX = re.compile("|".join(CREDENTIAL_TOKEN_PATTERNS), re.IGNORECASE)
+
+FILE_PATH_TOOLS = {"Read", "Edit", "Write", "NotebookEdit"}
+PATH_SEARCH_TOOLS = {"Grep", "Glob"}
+
+DENY_REASON = (
+    "Blocked by CodeFluent secrets-protection hook (.claude/hooks/block_secret_reads.py). "
+    "This file is a likely credential source (.env, shell rc, SSH key, or named secrets file). "
+    "Reading it would persist its contents in the Claude Code session JSONL. "
+    "If you need to verify the file exists, use `test -f <path>`. "
+    "See SECURITY.md for the full policy."
+)
+
+
+def path_is_blocked(path_str: str) -> bool:
+    if not path_str:
+        return False
+    p = PurePath(path_str)
+    name = p.name
+    if name in BLOCKED_BASENAMES:
+        return True
+    if p.suffix in BLOCKED_SUFFIXES:
+        return True
+    if name.startswith((".env.", ".env-", ".env_")):
+        return True
+    parts = p.parts
+    for suffix in BLOCKED_PATH_SUFFIXES:
+        if len(parts) >= len(suffix) and parts[-len(suffix):] == suffix:
+            return True
+    return False
+
+
+def bash_command_is_blocked(command: str) -> bool:
+    if not command:
+        return False
+    return CREDENTIAL_TOKEN_REGEX.search(command) is not None
+
+
+def check(event: dict) -> tuple[bool, str]:
+    tool_name = event.get("tool_name", "")
+    tool_input = event.get("tool_input") or {}
+
+    if tool_name in FILE_PATH_TOOLS:
+        path = tool_input.get("file_path") or tool_input.get("notebook_path") or ""
+        if path_is_blocked(path):
+            return True, f"{DENY_REASON} (path: {path})"
+
+    if tool_name in PATH_SEARCH_TOOLS:
+        path = tool_input.get("path") or ""
+        pattern = tool_input.get("pattern") or ""
+        if path and path_is_blocked(path):
+            return True, f"{DENY_REASON} (search path: {path})"
+        if pattern and CREDENTIAL_TOKEN_REGEX.search(pattern):
+            return True, f"{DENY_REASON} (search pattern targets credential file: {pattern})"
+
+    if tool_name == "Bash":
+        command = tool_input.get("command") or ""
+        if bash_command_is_blocked(command):
+            return True, f"{DENY_REASON} (command: {command[:200]})"
+
+    return False, ""
+
+
+def emit_decision(decision: str, reason: str) -> None:
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": decision,
+            "permissionDecisionReason": reason,
+        }
+    }
+    sys.stdout.write(json.dumps(payload))
+
+
+def main() -> int:
+    try:
+        event = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError) as e:
+        # Fail closed: this is a security-critical PreToolUse hook. If we can't
+        # parse the event we cannot confirm the call is safe, so deny rather
+        # than allow through a malformed event of unknown provenance.
+        print(
+            f"block_secret_reads: failed to parse hook event JSON, denying by default: {e}",
+            file=sys.stderr,
+        )
+        return 2
+
+    blocked, reason = check(event)
+    if blocked:
+        emit_decision("deny", reason)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/detect_secrets_in_output.py
+++ b/.claude/hooks/detect_secrets_in_output.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: block Claude from reasoning about tool output with secrets.
+
+PostToolUse cannot redact non-MCP tool output inline. Instead, this hook uses
+the detect-and-block pattern: if the tool response contains a known API key
+or token pattern, it emits `{"decision": "block", "reason": ...}` so Claude
+Code surfaces a block signal alongside the result and Claude knows not to
+echo, summarize, or otherwise act on the leaked value.
+
+Caveat: PostToolUse fires AFTER the tool has executed. The raw output is
+already persisted in the session JSONL, and Claude still technically receives
+the tool_result in-session. This hook prevents further propagation (summaries,
+follow-up prompts quoting the value) but does NOT prevent the on-disk leak.
+The PreToolUse block_secret_reads.py hook is the primary defense against
+on-disk leakage; this is a secondary guard.
+
+Cross-platform: stdlib only.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}"), "anthropic-key"),
+    (re.compile(r"sk-proj-[A-Za-z0-9_-]{20,}"), "openai-project-key"),
+    (re.compile(r"sk-[A-Za-z0-9]{40,}"), "openai-key-legacy"),
+    (re.compile(r"ghp_[A-Za-z0-9]{30,}"), "github-pat-classic"),
+    (re.compile(r"github_pat_[A-Za-z0-9_]{40,}"), "github-pat-fine"),
+    (re.compile(r"AKIA[A-Z0-9]{16}"), "aws-access-key-id"),
+    (re.compile(r"AIza[A-Za-z0-9_-]{35}"), "gcp-api-key"),
+]
+
+DENY_REASON_TEMPLATE = (
+    "Blocked by CodeFluent secrets-protection hook "
+    "(.claude/hooks/detect_secrets_in_output.py). "
+    "Tool output contained a value matching a known credential pattern: {kinds}. "
+    "Claude is being prevented from reasoning about this output to avoid further "
+    "propagation (e.g. echoing in summaries). "
+    "IMPORTANT: the raw value has already been persisted in the session JSONL "
+    "because PostToolUse fires after tool execution. Rotate any key that may have "
+    "leaked and see SECURITY.md for full remediation steps."
+)
+
+
+def stringify_response(resp: object) -> str:
+    """Coerce tool_response (dict, list, str, etc.) into a single searchable string."""
+    if isinstance(resp, str):
+        return resp
+    try:
+        return json.dumps(resp, default=str)
+    except (TypeError, ValueError):
+        return str(resp)
+
+
+def find_secret_kinds(text: str) -> list[str]:
+    kinds: list[str] = []
+    for pattern, label in SECRET_PATTERNS:
+        if pattern.search(text):
+            kinds.append(label)
+    return kinds
+
+
+def emit_block(reason: str) -> None:
+    payload = {"decision": "block", "reason": reason}
+    sys.stdout.write(json.dumps(payload))
+
+
+def main() -> int:
+    try:
+        event = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError) as e:
+        print(
+            f"detect_secrets_in_output: failed to parse hook event JSON: {e}",
+            file=sys.stderr,
+        )
+        return 0
+
+    response = event.get("tool_response")
+    if response is None:
+        return 0
+
+    text = stringify_response(response)
+    kinds = find_secret_kinds(text)
+    if kinds:
+        reason = DENY_REASON_TEMPLATE.format(kinds=", ".join(sorted(set(kinds))))
+        emit_block(reason)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,23 +1,41 @@
 {
   "hooks": {
-    "PostToolUse": [
+    "PreToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Read|Edit|Write|Grep|Glob|NotebookEdit|Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "file=$(echo \"$TOOL_INPUT\" | jq -r '.path // .file_path // empty'); if [[ \"$file\" == *.html ]] || [[ \"$file\" == *.htm ]]; then if grep -q '<script' \"$file\" 2>/dev/null; then if grep -L 'nonce=' \"$file\" | grep -q .; then echo \"Error: HTML file $file contains <script> tags without nonce attribute. All scripts must have nonce attribute for CSP compliance.\"; exit 1; fi; fi; fi"
+            "command": "python3 .claude/hooks/block_secret_reads.py"
           }
         ]
-      }
-    ],
-    "PreToolUse": [
+      },
       {
         "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
             "command": "echo \"$TOOL_INPUT\" | jq -r '.command' | grep -qE '\\b(git\\s+(commit|merge)|npm\\s+run\\s+build|make\\s+release)\\b' && (find . -name '*.test.*' -o -name '*_test.*' -o -name 'test_*' -o -name '__tests__' -type d | grep -q . || (echo 'No test files found. All new features must have tests before committing/merging.' && exit 1)) || exit 0"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Read|Grep|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/detect_secrets_in_output.py"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file=$(echo \"$TOOL_INPUT\" | jq -r '.path // .file_path // empty'); if [[ \"$file\" == *.html ]] || [[ \"$file\" == *.htm ]]; then if grep -q '<script' \"$file\" 2>/dev/null; then if grep -L 'nonce=' \"$file\" | grep -q .; then echo \"Error: HTML file $file contains <script> tags without nonce attribute. All scripts must have nonce attribute for CSP compliance.\"; exit 1; fi; fi; fi"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ When adding features or changing architecture, check this list for files that ma
 |------|---------|----------------|
 | `CLAUDE.md` | AI coding instructions, architecture, conventions, commands | Adding files, commands, test suites, or CI workflows |
 | `README.md` | Public-facing project overview, features, setup, eval framework | Adding user-visible features, changing test counts, updating setup steps |
+| `SECURITY.md` | Vulnerability reporting + full secrets-handling policy (hooks, audit, forward-compat rule) | Changing hook behavior, adding display surfaces that quote session content, or changing the key-rotation guidance |
 | `vscode-extension/README.md` | Extension setup, features, screenshots, marketplace listing | Changing extension features, installation steps, or screenshots |
 | `webapp/README.md` | Webapp setup, design choices, security, testing | Changing webapp features, test counts, security controls, or API surface |
 | `shared/eval/README.md` | Golden set structure, eval runner CLI, checks, CI integration | Changing eval checks, CLI options, test counts, or CI workflow |
@@ -354,6 +355,26 @@ When implementing from a PM-produced spec or issue:
 - **No regressions:** `npm test` must pass (currently 907 tests) before any commit to main.
 - **Feature parity:** Both the VS Code extension and the webapp are production deliverables. New scoring/analytics features should be implemented in both. Security fixes (XSS, injection) apply to both `media/app.js` and `webapp/static/app.js`.
 - **E2E testing:** Every PR test plan must include manual Playwright MCP smoke testing of the webapp before merging. See the E2E Smoke Test Checklist below.
+
+## Secrets handling
+
+Do not read `.env`, `.envrc`, `credentials.json`, `secrets.ya?ml`, SSH private keys (`id_rsa`, `id_ed25519`, `*.pem`), shell rc files (`.bashrc`, `.bash_profile`, `.profile`, `.zshrc`, `.zshenv`, `.zprofile`), or `webapp/config.json`.
+
+Anything read via Read, Bash (`cat`, `grep`, `source`), or Grep is persisted verbatim in the Claude Code session JSONL at `~/.claude/projects/<slug>/*.jsonl` — plaintext, forever. `.gitignore` does not protect against this.
+
+Two hooks enforce the rule:
+
+- **`.claude/hooks/block_secret_reads.py`** (PreToolUse) — denies Read/Edit/Write/Grep/Glob/NotebookEdit/Bash calls targeting the files above. A block message from this hook means the read was prevented *before* it executed, so nothing leaked.
+- **`.claude/hooks/detect_secrets_in_output.py`** (PostToolUse) — scans Read/Grep/Bash output for known secret patterns (`sk-ant-*`, `sk-proj-*`, `ghp_*`, `github_pat_*`, `AKIA*`, `AIza*`). A block message from this hook means the tool already executed and the raw value was persisted to the JSONL transcript. Report to the user that the key is compromised and should be rotated. Do not retry the same command.
+
+The rule generalizes beyond what the hooks catch:
+
+- If a tool result contains credential-looking values, never echo them in replies.
+- Do not emit generated code that prints env vars matching `KEY|TOKEN|SECRET|PASSWORD`.
+- To verify a credential file exists, use `test -f <path>` rather than reading it.
+- Any new feature that renders session content to the user (prompt excerpts, diffs, summaries) must re-apply secret-pattern redaction at the display layer — see the Production Standards security bullet above for the canonical redaction helpers.
+
+See [`SECURITY.md`](SECURITY.md) for the full policy, layered defense model, the audit one-liner for historical leaks, and the bypass surface the hooks do not cover.
 
 ## JSONL Data Format (VERIFIED against real data)
 

--- a/README.md
+++ b/README.md
@@ -310,6 +310,19 @@ Cost: ~$0.25 for a full 50-entry run, ~$0.15 for CI (33-entry subset). See [`sha
 
 All user-controlled strings are escaped before rendering in HTML. Shell commands use argument arrays (`execFileSync`) instead of string interpolation. The webapp validates all inputs with Pydantic models and enforces rate limits. Security-focused test suites verify XSS and injection protections.
 
+### Secrets handling
+
+CodeFluent parses `~/.claude/projects/` — and those JSONL files can contain anything Claude Code has ever read during a session, including your own `.env` files. `.gitignore` doesn't prevent this local persistence. If the session that leaked a credential was the one where you set up CodeFluent's API key, the key ends up in the same data CodeFluent analyzes.
+
+This repo ships two Claude Code hooks in [`.claude/settings.json`](.claude/settings.json) that reduce the risk:
+
+- **PreToolUse block** ([`.claude/hooks/block_secret_reads.py`](.claude/hooks/block_secret_reads.py)) — denies reads of `.env` variants, shell rc files, SSH keys, `credentials.json`, `secrets.{yaml,yml,json}`, `*.pem`, and `webapp/config.json`. Blocks *before* execution, so nothing enters the transcript.
+- **PostToolUse detect** ([`.claude/hooks/detect_secrets_in_output.py`](.claude/hooks/detect_secrets_in_output.py)) — if a tool result contains an `sk-ant-*`, `sk-proj-*`, `ghp_*`, `github_pat_*`, `AKIA*`, or `AIza*` token, emits a block signal so Claude doesn't echo or summarize it. Caveat: the raw value is already on disk at this point — rotate any key it catches.
+
+Any future CodeFluent feature that renders raw session content (diff viewers, prompt excerpts, coaching snippets) must re-apply secret-pattern redaction at the display layer — existing `_sanitize_error()` (webapp) and `sanitizeError()` (extension) helpers are the pattern to reuse.
+
+See [`SECURITY.md`](SECURITY.md) for the full policy: leak vector, defense architecture, discipline rules, historical-leak audit one-liner, user-scope deployment, and the bypass surface the hooks do not cover.
+
 ## Troubleshooting
 
 | Problem | Solution |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,204 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities via GitHub's private vulnerability reporting on the [Security tab](https://github.com/frederick-douglas-pearce/codefluent/security) of this repository.
+
+**Do not open a public issue for security concerns.**
+
+(Private vulnerability reporting must be enabled in repo Settings → Code security → "Private vulnerability reporting". If the Security tab does not show a reporting form, please email the maintainer listed in the root `package.json` / `webapp/pyproject.toml` instead.)
+
+We aim to acknowledge reports within 5 business days.
+
+## Scope
+
+CodeFluent is a local-first analytics tool with two interfaces — a VS Code extension and a FastAPI webapp. Both read session JSONL files from `~/.claude/projects/` on the user's own machine, call the Anthropic API for fluency scoring, and shell out to `gh` and `ccusage` for repo context and usage data. Security concerns likely to be in scope:
+
+- XSS or injection via session content rendered in the webview or webapp UI
+- Command injection via project paths, repo names, or CLI arguments passed to `gh`, `ccusage`, or the terminal launcher
+- Path traversal in the webapp's project-scoping endpoints
+- Credential leakage (API keys, tokens) through error messages, logs, or session persistence
+- Insecure deserialization of JSONL content
+- Supply-chain issues in the VSIX bundle or Python dependencies
+
+## Supported Versions
+
+v1.x releases receive security fixes on the latest minor line. Upgrade to the newest `1.x` release to receive patches.
+
+---
+
+# Secrets handling for CodeFluent and Claude Code
+
+The rest of this document is the canonical reference for protecting API keys and other credentials from leaking into Claude Code's local session store. It applies whether you are developing CodeFluent or using it to analyze your own Claude Code sessions.
+
+## The leak vector
+
+Claude Code persists every tool call and its output to a JSONL transcript at `~/.claude/projects/<project-slug>/<session-id>.jsonl`. When Claude (or any of its subagents) reads a file containing secrets — a `.env`, a `credentials.json`, an SSH private key, or a shell rc file that exports `ANTHROPIC_API_KEY` — the file's contents land in two places in that transcript:
+
+- `.toolUseResult.stdout` — the raw tool output
+- `.message.content[0].content` — the tool_result block fed back to the model
+
+Both copies are plaintext and permanent. `.gitignore` prevents the file from being committed to git. It does **not** prevent Claude Code from persisting its contents locally.
+
+This is not a Claude Code bug. Session persistence is a product feature — you want Claude to remember what it saw. The problem is only that credentials are in the set of things Claude sometimes sees.
+
+This matters doubly for CodeFluent: the webapp reads its Anthropic API key from `webapp/.env` (or an environment variable), and the VS Code extension accepts a key via `.env` in the workspace root. If a Claude Code session ever reads either file, the key ends up in `~/.claude/projects/` — the same directory CodeFluent itself parses.
+
+## Defense-in-depth architecture
+
+CodeFluent ships two Claude Code hooks in `.claude/settings.json` to reduce this risk:
+
+### PreToolUse block (primary defense)
+
+Script: `.claude/hooks/block_secret_reads.py`
+
+Denies Read, Edit, Write, Grep, Glob, NotebookEdit, and Bash tool calls whose target file path (or Bash command text) matches a list of known credential-file patterns:
+
+- `.env`, `.env.*`, `.envrc`
+- `credentials`, `credentials.json`
+- `secrets.yaml`, `secrets.yml`, `secrets.json`
+- `*.pem`, `id_rsa`, `id_ed25519`, `id_ecdsa`, `id_dsa`
+- `.bashrc`, `.bash_profile`, `.profile`, `.zshrc`, `.zshenv`, `.zprofile`
+- `webapp/config.json` (path-scoped — the webapp's optional config overrides file, which sits in the config resolution chain and is a plausible place to stash an API key)
+
+**This is the only layer that actually prevents the on-disk leak.** Because it blocks the tool call before it executes, the file's contents never enter the JSONL transcript.
+
+### PostToolUse detect-and-block (secondary defense)
+
+Script: `.claude/hooks/detect_secrets_in_output.py`
+
+Scans Read, Grep, and Bash tool output for known API key patterns (`sk-ant-*`, `sk-proj-*`, `sk-*` legacy OpenAI, `ghp_*`, `github_pat_*`, `AKIA*`, `AIza*`). If a match is found, the hook emits a block signal that tells Claude not to reason about, echo, or summarize the output, even though the tool result itself still arrives in-session (PostToolUse fires after execution — Claude technically receives the output and then the block signal on top of it).
+
+**Important caveat.** PostToolUse fires *after* the tool has already executed, which means the raw output has already been written to the JSONL transcript. This layer prevents Claude from reasoning about the leaked value in the current session (which stops it from propagating into summaries or follow-up prompts), but it does **not** prevent the on-disk leak. For that, only the PreToolUse layer works.
+
+If a PostToolUse block fires, treat the underlying value as compromised and rotate it. The fact that it leaked once means it is in your local JSONL store forever.
+
+### Known bypass surface (documented, accepted)
+
+The hooks use pattern matching, which is not airtight. These cases are not caught:
+
+- Glob expansion: `cat .e*` or `cat ~/.env*`
+- Heredoc / Python tricks: `python -c "print(open('.env').read())"`
+- Indirection through a shell variable whose name does not contain `.env`
+- Base64-encoded or otherwise obfuscated filenames
+
+The hook is defense-in-depth against normal Claude usage, not a guarantee against a motivated adversary. Pair it with the discipline rules below.
+
+## Required discipline
+
+### Keep secrets in `.env` files only
+
+- Never `export ANTHROPIC_API_KEY=...` (or any other secret) in `.bashrc`, `.bash_profile`, `.profile`, `.zshrc`, `.zshenv`, or `.zprofile`. Environment exports leak via `env` / `printenv` / any subprocess that prints its environment in an error message — independently of file-read hooks.
+- Store secrets in a per-project `.env` file. Load them into your application at startup (`python-dotenv`, the VS Code extension's `.env` parser, `direnv` with explicit unload, etc.) — your code reads `.env`, Claude does not.
+- `.env` must be in `.gitignore`. That protects commits. The hook protects Claude's transcript.
+
+### Prefer VS Code SecretStorage for the extension
+
+The VS Code extension's API-key resolution order is: `ANTHROPIC_API_KEY` env var → workspace `.env` → VS Code SecretStorage → interactive prompt (result stored in SecretStorage). SecretStorage is backed by the OS keychain and is never persisted to a readable file. Prefer it over `.env` when you have the choice: enter the key through the interactive prompt once, and future sessions pick it up without any file on disk that Claude could read.
+
+### Scope your API key to CodeFluent alone
+
+CodeFluent needs an Anthropic API key only for fluency scoring, prompt optimization, and configuration-advisor generation. Create a dedicated key in the [Anthropic console](https://console.anthropic.com/settings/keys) and set a monthly spend cap on it — that way, any future leak or unexpected usage has a bounded blast radius.
+
+### Never paste raw secrets into Claude prompts
+
+No amount of hook configuration catches you pasting `sk-ant-...` into Claude's input. If you need Claude to debug credential handling, describe the shape of the value (`sk-ant-api03-<108 chars>`), never the value itself.
+
+### Rotate keys suspected of prior leakage
+
+If Claude read a `.env` or exported environment at any point before you installed these hooks, assume the key is leaked on disk. Rotate it:
+
+- Anthropic: <https://console.anthropic.com/settings/keys>
+- OpenAI: <https://platform.openai.com/api-keys>
+- GitHub: <https://github.com/settings/tokens> (classic) or <https://github.com/settings/personal-access-tokens/fine-grained>
+- AWS IAM: rotate the access key pair and revoke the old one.
+- Google Cloud: <https://console.cloud.google.com/apis/credentials>
+
+## Verifying the hook is active
+
+In a Claude Code session in this repo, ask Claude to read a file named `.env` (create one with throwaway content for testing). The tool call should return a block message starting with `"Blocked by CodeFluent secrets-protection hook"`.
+
+You can also inspect the settings file directly:
+
+```bash
+cat .claude/settings.json
+```
+
+and confirm the `PreToolUse` and `PostToolUse` entries are present.
+
+## Auditing your existing session store for historical leaks
+
+Run this one-liner against `~/.claude/projects/` to surface any JSONL files that contain known secret patterns:
+
+```bash
+grep -rlE '(sk-ant-[A-Za-z0-9_-]{20,}|sk-proj-[A-Za-z0-9_-]{20,}|ghp_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|AKIA[A-Z0-9]{16}|AIza[A-Za-z0-9_-]{35})' ~/.claude/projects/ 2>/dev/null
+```
+
+If it returns matches, rotate every key that appears and then decide how to handle the on-disk copies (see next section).
+
+## Historical JSONL cleanup
+
+If the audit surfaces leaked keys in existing JSONL files, you have three options:
+
+1. **Leave the files alone.** After rotation, the leaked keys are inert — they no longer authenticate. Residual risk: someone with local filesystem access could see the old key values, which may be useful for forensic reconstruction of your history but grants no API access.
+2. **Scrub the affected JSONL in place.** Write a script that rewrites each line, redacting values matching the secret patterns. Preserves the session structure for tools like CodeFluent and AgentFluent that read this data. Risk: any bug in the scrubbing script could corrupt legitimate session data.
+3. **Delete the affected session files entirely.** Clean but loses the analysis history.
+
+The default recommendation is option 1 (leave alone, after rotation). Only choose scrubbing or deletion if you have a specific reason — e.g., you know you will share a backup of `~/.claude/` with someone who should not see the old values.
+
+## Deploying the hooks at user scope as well
+
+The hooks shipped in `.claude/settings.json` protect contributors working on this repo. They do not protect your other work in other projects. Mirror the same hook configuration into `~/.claude/settings.json` to cover every Claude Code session on your machine, regardless of project:
+
+```bash
+# One-time setup: copy the hook scripts to a user-scoped location
+mkdir -p ~/.claude/hooks
+cp .claude/hooks/block_secret_reads.py ~/.claude/hooks/
+cp .claude/hooks/detect_secrets_in_output.py ~/.claude/hooks/
+
+# Then add matching PreToolUse / PostToolUse entries to ~/.claude/settings.json,
+# pointing the `command` fields at ~/.claude/hooks/*.py with absolute paths.
+```
+
+Note: the `webapp/config.json` path-scoped block is CodeFluent-specific and will simply never match in other projects, so it's safe to deploy at user scope as-is.
+
+### How project-level and user-level hooks interact
+
+Both scopes load. Per the Claude Code hooks documentation, *"all matching hooks run in parallel, and identical handlers are deduplicated automatically. Command hooks are deduplicated by command string."* That means:
+
+- If you copy the same hook configuration (same `command` string) into both `~/.claude/settings.json` and the project's `.claude/settings.json`, it runs once, not twice.
+- If the command strings differ (e.g. user-scope uses an absolute path like `python3 /home/you/.claude/hooks/block_secret_reads.py` while the project uses the relative path `python3 .claude/hooks/block_secret_reads.py`), both commands fire.
+
+Deploying at both scopes is safe and is the right move for layered coverage: project scope protects contributors on this repo; user scope protects every other Claude Code session on your machine.
+
+One subtlety: Claude Code's settings precedence rule — *"more specific scopes take precedence"* — applies to scalar settings like permissions (e.g. a project-scope `deny` overrides a user-scope `allow`). The hooks documentation describes its own merge behavior (parallel execution with command-string deduplication), which is why copying a hook into both scopes does not cause double execution.
+
+## Forward-compatibility rule for CodeFluent features
+
+CodeFluent already surfaces session content in several places. Any future feature that surfaces raw session content to the user — verbose diagnostics, prompt diff viewers, regression analysis, additional coaching snippets — **must re-apply secret-pattern redaction at the display layer**.
+
+Current display surfaces that render session-derived content (each a candidate for redaction as it evolves):
+
+- **Conversations detail view** — prompt excerpts pulled directly from session JSONL
+- **Prompt Optimizer** — accepts and returns prompt text, can quote user input verbatim
+- **Quick Wins** — suggestions may quote GitHub issue bodies or repo context
+- **Recommendations** — coaching snippets that reference user patterns
+- **Configuration Maturity / Enforcement Gaps** — renders raw `CLAUDE.md` statements as `gap.statement`, and the Configuration Advisor ships those statements to the Anthropic API via `generateHookConfig`
+
+The reason this matters: historical JSONL files on a user's machine may still contain leaked values from before the hooks were installed. A feature that reads session JSONL and shows text without redacting risks surfacing those historical leaks in UI output, log files, or exported reports.
+
+CodeFluent's existing API-key redaction helpers — `_sanitize_error()` in the webapp and `sanitizeError()` in the extension — cover the error-message path and currently strip `sk-ant-*` tokens. They are the right pattern to follow for any new display-layer consumer. Note that their coverage is narrower than the PostToolUse hook's pattern list; expanding them to cover all 7 patterns is tracked separately so new consumers can rely on the full set.
+
+Implementers of display-layer features should reuse the regex patterns from `.claude/hooks/detect_secrets_in_output.py` (or an equivalent helper extracted into the main codebase when the first consumer lands), rather than writing new pattern lists.
+
+## Scope limits
+
+These hooks protect the Claude-Code-transcript leak vector. They do not protect:
+
+- Secrets at rest on your filesystem (that is a filesystem permissions problem; use `chmod 600` on `.env` and similar)
+- Secrets in your shell history (`~/.bash_history`, `~/.zsh_history`)
+- Secrets logged by your own applications into log files
+- Secrets transmitted in network requests
+- Screen-capture or shoulder-surfing attacks
+
+For those threats, use the appropriate OS and application-level controls. This document and these hooks address only the narrow case of Claude Code persisting credentials into its session store.

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -144,9 +144,19 @@ CodeFluent uses the following resolution order:
 2. `.env` file in your workspace root
 3. VS Code SecretStorage (persisted after first prompt)
 
+**Prefer SecretStorage over `.env` when you have the choice.** SecretStorage is backed by your OS keychain and never persists to a readable file. If you enter the key through the interactive prompt, CodeFluent stores it in SecretStorage automatically and you don't need a workspace `.env` at all. See the [Secrets handling](#secrets-handling) note below for why this matters.
+
 ## Privacy
 
 All data stays on your machine. CodeFluent reads local session files and makes direct Anthropic API calls for scoring — no telemetry, no external servers, no data collection.
+
+### Secrets handling
+
+Claude Code persists every tool call and its output to JSONL transcripts at `~/.claude/projects/`. If Claude ever reads a `.env` file during a session (yours or one in your workspace), the contents of that file end up in those transcripts in plaintext — the same transcripts CodeFluent parses. `.gitignore` does not protect against this.
+
+To reduce the risk, prefer VS Code SecretStorage for your Anthropic API key (see above), scope the key to CodeFluent alone with a monthly spend cap in the [Anthropic console](https://console.anthropic.com/settings/keys), and never paste raw `sk-ant-*` values into Claude prompts.
+
+The CodeFluent repository itself ships Claude Code hooks that block reads of `.env`, SSH keys, and other credential files during development — see [`SECURITY.md`](https://github.com/frederick-douglas-pearce/codefluent/blob/main/SECURITY.md) for the full policy, an audit one-liner for historical leaks in your existing `~/.claude/projects/`, and instructions for deploying the same hooks at user scope to protect all your Claude Code sessions.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Closes #270. Ships the secret-handling hooks already committed on this branch and the surrounding documentation that makes them discoverable.

- PreToolUse block (`block_secret_reads.py`) denies reads of credential files before they execute, preventing the contents from ever landing in Claude Code's JSONL transcripts
- PostToolUse detect (`detect_secrets_in_output.py`) scans tool output for known key patterns and signals Claude not to echo the value; flags the value as compromised since it's already on disk at that layer
- `SECURITY.md` at repo root is the canonical policy: vulnerability reporting, leak vector explanation, defense architecture, discipline rules, audit one-liner, historical JSONL cleanup options, user-scope deployment, and the forward-compat rule for new display surfaces
- `CLAUDE.md` gets a Secrets handling section for future Claude Code agents working in the repo, plus a Documentation Map row for `SECURITY.md`
- `README.md` + `vscode-extension/README.md` get user-facing secrets sections pointing at `SECURITY.md`
- Architect reviewed the plan at comment on #270; all blocking concerns addressed (Config Maturity / Enforcement Gaps included in the forward-compat display-surface list; `webapp/config.json` added to block list path-scoped to avoid false positives)
- `/simplify` review addressed: derived the `webapp/config.json` bash regex from `BLOCKED_PATH_SUFFIXES` to eliminate the double-source drift hazard; tightened comments; split a long opener and bulletized the final paragraph in the CLAUDE.md section

Follow-up tracked separately in #271: expand `_sanitize_error()` / `sanitizeError()` to cover all 7 hook-detected patterns (currently only `sk-ant-*`).

## Why merge first

PR #269 needs a live Anthropic API call to validate the task_type_agreement check and requires setting up a new codefluent-scoped key in `webapp/.env`. Until these hooks and docs are in place, that new key is exposed to the session-persistence leak vector from the moment it enters the file. Sequence: merge this → rebase #269 on top → run live eval → merge #269.

## Test plan

- [x] Hook AC1 branding: DENY_REASON in both hook scripts says "CodeFluent" (not "AgentFluent") and references `SECURITY.md` at repo root. Verified via manual test script (all 8 checks pass).
- [x] Hook AC2 block list: `webapp/config.json` blocked via path-scoped match; bare `config.json` in other directories NOT blocked (no false positives). Verified via manual test covering relative path, absolute path, bash command matches, and explicit no-match cases.
- [x] `SECURITY.md` covers all AC3 bullets (vulnerability reporting, scope, leak vector, defense architecture, bypass surface, discipline rules, verification, audit one-liner, cleanup options, user-scope deployment, forward-compat rule with Config Maturity / Enforcement Gaps surface, scope limits).
- [x] `CLAUDE.md` Secrets handling section + Documentation Map row for `SECURITY.md`.
- [x] `README.md` and `vscode-extension/README.md` Secrets sections link to `SECURITY.md`.
- [x] Hook meta-verification during implementation: the hooks blocked both `gh issue create` and `git commit -m` commands whose bodies contained `.env` references — real dogfooding confirmation that the PreToolUse Bash-text regex works end-to-end.
- [ ] Reviewer: verify hooks still work after merge by running `python3 .claude/hooks/block_secret_reads.py` with a fake event payload (e.g. `{"tool_name":"Read","tool_input":{"file_path":".env"}}`) and confirming the deny message cites CodeFluent.
- [ ] Reviewer: confirm the Secrets handling section in `CLAUDE.md` reads cleanly alongside the existing Production Standards security bullet (no awkward overlap).
