### PR TITLE
chore: gate security-review on label, add path filter, pin SHA (#283)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,6 @@
 - [ ] Unit tests pass: `npm test` (vscode-extension) and `uv run pytest tests/` (webapp)
 - [ ] E2E smoke test via Playwright MCP (see CLAUDE.md checklist) — required for UI/API changes
 - [ ] No security regressions (XSS, injection, path traversal)
+
+## Pre-merge checklist
+- [ ] Add `needs-security-review` label and confirm review passes before merging

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -2,6 +2,19 @@ name: Security Review
 
 on:
   pull_request:
+    types: [labeled]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'images/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - 'LICENSE'
+      - 'CHANGELOG.md'
+
+concurrency:
+  group: security-review-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   pull-requests: write
@@ -9,24 +22,41 @@ permissions:
 
 jobs:
   security:
-    # Skip for Dependabot PRs (no access to secrets)
-    if: github.actor != 'dependabot[bot]'
+    # Triggered only when the `needs-security-review` label is added — see #283.
+    # Dependabot PRs don't have access to secrets, so they're excluded.
+    if: github.event.label.name == 'needs-security-review' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
-      - uses: anthropics/claude-code-security-review@main
+      # Pinned to a SHA for supply-chain safety — upstream has no tagged releases.
+      - uses: anthropics/claude-code-security-review@0c6a49f1fa56a1d472575da86a94dbc1edb78eda # 2026-02-11
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
           comment-pr: true
           claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-          exclude-directories: node_modules,out,data,.claude
+          # Pin to Sonnet; routine security scans don't need Opus-level reasoning.
+          claude-model: claude-sonnet-4-6
+          # Excludes build artifacts and caches only. .claude/ is intentionally
+          # NOT excluded — it contains hook scripts and settings that handle
+          # credentials and execute arbitrary shell on every tool call.
+          exclude-directories: node_modules,out,data,.venv,dist,build,.mypy_cache,.pytest_cache,.ruff_cache,coverage
           custom-security-scan-instructions: |
-            This project has two attack surfaces:
-            1. VS Code webview (media/app.js) — nonce-based CSP, must use escapeHtml() for all user strings
-            2. Web app (webapp/static/app.js + webapp/main.py) — localhost-only CORS, Pydantic validation
+            This project has three attack surfaces:
+            1. VS Code webview (media/app.js) — nonce-based CSP, must use escapeHtml()
+               for all user strings.
+            2. Web app (webapp/static/app.js + webapp/main.py) — localhost-only CORS,
+               Pydantic validation.
+            3. Project-scope Claude Code config (.claude/) — hooks (.claude/hooks/*.py +
+               .claude/settings.json) execute arbitrary shell on every tool call and
+               handle credential redaction; agent definitions (.claude/agents/*.md)
+               control tool permissions; custom slash commands (.claude/commands/*.md)
+               feed prompts to LLMs.
             Pay special attention to: XSS via HTML injection, shell command injection via
-            unsanitized input to subprocess/execFileSync, and path traversal in the data_path parameter.
+            unsanitized input to subprocess/execFileSync, path traversal in the
+            data_path parameter, hook scripts that write secret-pattern matches verbatim
+            to logs (defeating their own redaction), and agent definitions that grant
+            overly-broad tool access.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,7 +294,7 @@ chore: bump @anthropic-ai/sdk to 0.52.0
 ### CI Workflows
 - **`ci.yml`** — Runs on every PR: `npm test` (907 tests) in `vscode-extension/`, `pytest` (746 tests) in `webapp/`
 - **`eval.yml`** — Runs on PRs touching `shared/prompts/**`: scores golden set (33 entries) via Anthropic API, validates schema + agreement (~$0.15/run). Skipped for Dependabot.
-- **`security-review.yml`** — Runs on every PR: grep-based checks for security anti-patterns (inline onclick, string interpolation in shell commands, missing escapeHtml)
+- **`security-review.yml`** — Claude-powered security review via `anthropics/claude-code-security-review`. Triggered by `needs-security-review` label on PR (not on every push, to control API costs). Skipped on docs-only PRs and Dependabot. Scans webview (`media/app.js`), webapp (`webapp/`), and project Claude config (`.claude/hooks/`, `.claude/settings.json`, `.claude/agents/`).
 - **`claude-review.yml`** — AI code review via `claude-code-action@v1`. Triggered by `needs-review` label on PR (not on every push, to control API costs). Also responds to `@claude` mentions in PR comments.
 - **`release-please.yml`** — Auto-creates release PRs with changelog + version bumps from conventional commits. When a release is created, chains into a `build-release` job that builds VSIX, publishes to Marketplace, uploads to GitHub Release, and marks the release as non-draft.
 - **`release.yml`** — Manual fallback (`workflow_dispatch` only) for retrying failed releases or manual tag releases. Not triggered automatically.


### PR DESCRIPTION
## Summary
- Gates Claude-powered security-review on a `needs-security-review` label so it runs once per merge cycle instead of on every push (3-6× cost reduction per PR)
- Removes `.claude/` from `exclude-directories` — the directory contains hook scripts, settings, and agent definitions that ARE security-relevant; ports `paths-ignore`, concurrency cancellation, pinned action SHA, and explicit model from the AgentFluent equivalent
- Updates PR template with a pre-merge checklist item to remind contributors to add the label; fixes the stale "grep-based checks" description in CLAUDE.md (the action is actually Claude-powered)

Closes #283.

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `needs-security-review` label created in repo
- [x] PR template includes pre-merge checklist item
- [x] CLAUDE.md description matches reality
- [x] **Manual smoke test on this PR**: add the `needs-security-review` label and confirm the workflow runs against this PR's diff. Without the label, the workflow should not trigger on subsequent pushes.

## Pre-merge checklist
- [x] Add `needs-security-review` label and confirm review passes before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
