### PR TITLE
chore: align engines.vscode with @types/vscode (re-enables v1.2.0 release)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -25,7 +25,7 @@
     "theme": "dark"
   },
   "engines": {
-    "vscode": "^1.115.0"
+    "vscode": "^1.116.0"
   },
   "icon": "media/icon.png",
   "categories": [


### PR DESCRIPTION
## Summary
- Bumps `engines.vscode` to `^1.116.0` to match `@types/vscode`, which Dependabot raised in #275 without re-aligning engines.
- Unblocks the v1.2.0 release: the release-please **Build & Release** job failed at `vsce package` with `@types/vscode ^1.116.0 greater than engines.vscode ^1.115.0`.
- Same recurrence pattern as 3cfb4b9. Process follow-ups (add `vsce package` to CI; group/pin `@types/vscode`) tracked separately.

## Test plan
- [x] `npm ci && npx @vscode/vsce package --allow-missing-repository` succeeds locally (1.67 MB VSIX, 1635 files)
- [x] `npm run compile` succeeds
- [x] CI green on this PR
- [x] After merge: delete the ghost v1.2.0 GitHub release + tag, re-tag at the new merge commit, manually trigger `release.yml` with `tag=v1.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)