### PR TITLE
chore: sync webapp/uv.lock with pyproject.toml v1.2.0

### DIFF
--- a/webapp/uv.lock
+++ b/webapp/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "codefluent"
-version = "1.1.0"
+version = "1.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Updates `webapp/uv.lock` to record `codefluent==1.2.0`, matching `webapp/pyproject.toml` (which release-please bumped in #230).
- Without this, every contributor's first `uv sync` after pulling main produces this exact diff as untracked working-tree noise.
- One-line lockfile change. No code changes, no behavior change.

## Why this happened
release-please's `generic` updater bumped the version string in `webapp/pyproject.toml` but doesn't know about uv lockfiles. Tracked as a separate v1.3 issue so we don't repeat this for v1.3+.

## Test plan
- [x] `git diff` is exactly one line: `version = \"1.1.0\"` → `version = \"1.2.0\"` in the `[[package]] name = \"codefluent\"` block
- [x] `cd webapp && uv sync` is a no-op after this change (lockfile already in sync)
- [x] CI green (`Run Tests` + `Run Webapp Tests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)