### PR TITLE
chore: add vsce package gate to ci.yml (#292)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,21 @@ jobs:
         working-directory: vscode-extension
         run: npm test
 
+      - name: Package VSIX
+        working-directory: vscode-extension
+        run: npx @vscode/vsce package --allow-missing-repository
+
+      - name: Verify VSIX size
+        working-directory: vscode-extension
+        run: |
+          VSIX=$(ls *.vsix)
+          SIZE=$(stat --format=%s "$VSIX")
+          echo "VSIX: $VSIX ($SIZE bytes)"
+          if [ "$SIZE" -lt 500000 ]; then
+            echo "ERROR: VSIX is too small (<500KB) — node_modules likely excluded"
+            exit 1
+          fi
+
       - name: Audit dependencies
         working-directory: vscode-extension
         run: npm audit --audit-level=high

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,7 +293,7 @@ chore: bump @anthropic-ai/sdk to 0.52.0
 4. Release Please creates the git tag → triggers `release.yml` → builds VSIX → publishes to Marketplace
 
 ### CI Workflows
-- **`ci.yml`** — Runs on every PR: `npm test` (942 tests) in `vscode-extension/`, `pytest` (799 tests) in `webapp/`
+- **`ci.yml`** — Runs on every PR: `npm test` (942 tests) + `vsce package` (catches `engines.vscode` / `@types/vscode` mismatches and `.vscodeignore` misconfig pre-merge) in `vscode-extension/`, `pytest` (799 tests) in `webapp/`
 - **`eval.yml`** — Runs on PRs touching `shared/prompts/**`, `shared/defaults.json`, or `shared/eval/scorer.py`: scores golden set (79 CI entries / 84 total) via Anthropic API, validates schema + agreement (~$0.30/run). Skipped for Dependabot.
 - **`security-review.yml`** — Claude-powered security review via `anthropics/claude-code-security-review`. Triggered by `needs-security-review` label on PR (not on every push, to control API costs). Skipped on docs-only PRs and Dependabot. Scans webview (`media/app.js`), webapp (`webapp/`), and project Claude config (`.claude/hooks/`, `.claude/settings.json`, `.claude/agents/`).
 - **`claude-review.yml`** — AI code review via `claude-code-action@v1`. Triggered by `needs-review` label on PR (not on every push, to control API costs). Also responds to `@claude` mentions in PR comments.


### PR DESCRIPTION
## Summary
- Adds `npx @vscode/vsce package --allow-missing-repository` and a `Verify VSIX size` step to `ci.yml`, mirroring what `release.yml` already runs.
- Catches `engines.vscode` / `@types/vscode` misalignments and `.vscodeignore` misconfiguration **on PR** instead of at release time — same class of bug that ghosted v1.2.0's first release attempt.
- Updates the CLAUDE.md CI workflows note to reflect the new gate.

## Why now
First v1.2.1 prep PR. Lands the guardrail before #297 (the chart fix) is built so the patch release pipeline has the same discipline that release-please / `release.yml` enforce — see [issue #292](https://github.com/frederick-douglas-pearce/codefluent/issues/292) for the full rationale + history.

## Test plan
- [x] PR's own CI run executes the new `Package VSIX` and `Verify VSIX size` steps successfully (current `engines.vscode ^1.116.0` and `@types/vscode ^1.116.0` are aligned)
- [ ] Confirm CI fails when versions are misaligned: after this lands, push a throwaway branch that bumps `@types/vscode` to `^1.117.0` and verify the new `Package VSIX` step exits non-zero. Discard the branch.
- [ ] Confirm CI fails on a misconfigured `.vscodeignore`: throwaway branch that adds `node_modules/` to `.vscodeignore` and verify `Verify VSIX size` reports VSIX < 500KB. Discard.

## Closes
Closes #292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)