### PR TITLE
chore: replace hardcoded VSIX size check with node_modules presence check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,13 @@ jobs:
         working-directory: vscode-extension
         run: npx @vscode/vsce package --allow-missing-repository
 
-      - name: Verify VSIX size
+      - name: Verify VSIX runtime dependencies
         working-directory: vscode-extension
         run: |
           VSIX=$(ls *.vsix)
-          SIZE=$(stat --format=%s "$VSIX")
-          echo "VSIX: $VSIX ($SIZE bytes)"
-          if [ "$SIZE" -lt 500000 ]; then
-            echo "ERROR: VSIX is too small (<500KB) — node_modules likely excluded"
+          echo "VSIX: $VSIX"
+          if ! unzip -l "$VSIX" | grep -q '/node_modules/'; then
+            echo "ERROR: VSIX missing node_modules/ — runtime deps excluded (check .vscodeignore)"
             exit 1
           fi
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -66,14 +66,13 @@ jobs:
         working-directory: vscode-extension
         run: npx @vscode/vsce package --allow-missing-repository
 
-      - name: Verify VSIX size
+      - name: Verify VSIX runtime dependencies
         working-directory: vscode-extension
         run: |
           VSIX=$(ls *.vsix)
-          SIZE=$(stat --format=%s "$VSIX")
-          echo "VSIX: $VSIX ($SIZE bytes)"
-          if [ "$SIZE" -lt 500000 ]; then
-            echo "ERROR: VSIX is too small (<500KB) — node_modules likely excluded"
+          echo "VSIX: $VSIX"
+          if ! unzip -l "$VSIX" | grep -q '/node_modules/'; then
+            echo "ERROR: VSIX missing node_modules/ — runtime deps excluded (check .vscodeignore)"
             exit 1
           fi
           echo "vsix_path=vscode-extension/$VSIX" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,14 +58,13 @@ jobs:
         working-directory: vscode-extension
         run: npx @vscode/vsce package --allow-missing-repository
 
-      - name: Verify VSIX size
+      - name: Verify VSIX runtime dependencies
         working-directory: vscode-extension
         run: |
           VSIX=$(ls *.vsix)
-          SIZE=$(stat --format=%s "$VSIX")
-          echo "VSIX: $VSIX ($SIZE bytes)"
-          if [ "$SIZE" -lt 500000 ]; then
-            echo "ERROR: VSIX is too small (<500KB) — node_modules likely excluded"
+          echo "VSIX: $VSIX"
+          if ! unzip -l "$VSIX" | grep -q '/node_modules/'; then
+            echo "ERROR: VSIX missing node_modules/ — runtime deps excluded (check .vscodeignore)"
             exit 1
           fi
           echo "vsix_path=vscode-extension/$VSIX" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- Replaces the hardcoded \`SIZE -lt 500000\` check in **all three** VSIX-packaging workflows (\`ci.yml\`, \`release.yml\`, \`release-please.yml\`) with a direct \`unzip -l \"\$VSIX\" | grep -q '/node_modules/'\` check.
- Tests the actual invariant we care about — the VSIX must contain \`node_modules/\` because \`@anthropic-ai/sdk\` is a runtime dependency — instead of using file size as a brittle proxy.
- Renames the step from **Verify VSIX size** to **Verify VSIX runtime dependencies** to reflect what it actually checks.

## Why
Follow-up to #292 / #299 (CI vsce-package gate) — feedback noted the magic-number 500000 in the bash check. The 500KB threshold was a proxy for \"node_modules got included.\" The proxy is brittle (could false-positive if VSIX legitimately shrinks; could false-negative if something else big sneaks in). Direct check is more accurate, self-documenting, and removes the magic number.

The same hardcoded 500000 also lived in \`release.yml\` and \`release-please.yml\`'s \`build-release\` job (pre-existing, not introduced by #299) — fixing all three for consistency.

## Test plan
- [x] Verified pattern matches against a real VSIX locally — \`unzip -l codefluent-1.2.0.vsix | grep -c '/node_modules/'\` returned 1561 (entries are prefixed \`extension/node_modules/...\` per VSIX layout, but grep matches \`/node_modules/\` regardless of prefix)
- [x] Verified the new check would catch the failure mode — an excluded \`node_modules/\` would produce zero matches and exit 1
- [x] CI green on this PR's own run (the new \`Verify VSIX runtime dependencies\` step runs on this very PR)
- [ ] (Optional manual verification, not required to merge) Push a throwaway branch that adds \`node_modules/\` to \`.vscodeignore\` and confirm the new step exits non-zero

## Related
- #292 / #299 — original CI gate that introduced the proxy
- v1.2 milestone release-tooling theme (#296 still pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)