### PR TITLE
[TEST — DO NOT MERGE] verify VSIX node_modules gate negative case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,13 @@ jobs:
         working-directory: vscode-extension
         run: npx @vscode/vsce package --allow-missing-repository
 
-      - name: Verify VSIX size
+      - name: Verify VSIX runtime dependencies
         working-directory: vscode-extension
         run: |
           VSIX=$(ls *.vsix)
-          SIZE=$(stat --format=%s "$VSIX")
-          echo "VSIX: $VSIX ($SIZE bytes)"
-          if [ "$SIZE" -lt 500000 ]; then
-            echo "ERROR: VSIX is too small (<500KB) — node_modules likely excluded"
+          echo "VSIX: $VSIX"
+          if ! unzip -l "$VSIX" | grep -q '/node_modules/'; then
+            echo "ERROR: VSIX missing node_modules/ — runtime deps excluded (check .vscodeignore)"
             exit 1
           fi
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -66,14 +66,13 @@ jobs:
         working-directory: vscode-extension
         run: npx @vscode/vsce package --allow-missing-repository
 
-      - name: Verify VSIX size
+      - name: Verify VSIX runtime dependencies
         working-directory: vscode-extension
         run: |
           VSIX=$(ls *.vsix)
-          SIZE=$(stat --format=%s "$VSIX")
-          echo "VSIX: $VSIX ($SIZE bytes)"
-          if [ "$SIZE" -lt 500000 ]; then
-            echo "ERROR: VSIX is too small (<500KB) — node_modules likely excluded"
+          echo "VSIX: $VSIX"
+          if ! unzip -l "$VSIX" | grep -q '/node_modules/'; then
+            echo "ERROR: VSIX missing node_modules/ — runtime deps excluded (check .vscodeignore)"
             exit 1
           fi
           echo "vsix_path=vscode-extension/$VSIX" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,14 +58,13 @@ jobs:
         working-directory: vscode-extension
         run: npx @vscode/vsce package --allow-missing-repository
 
-      - name: Verify VSIX size
+      - name: Verify VSIX runtime dependencies
         working-directory: vscode-extension
         run: |
           VSIX=$(ls *.vsix)
-          SIZE=$(stat --format=%s "$VSIX")
-          echo "VSIX: $VSIX ($SIZE bytes)"
-          if [ "$SIZE" -lt 500000 ]; then
-            echo "ERROR: VSIX is too small (<500KB) — node_modules likely excluded"
+          echo "VSIX: $VSIX"
+          if ! unzip -l "$VSIX" | grep -q '/node_modules/'; then
+            echo "ERROR: VSIX missing node_modules/ — runtime deps excluded (check .vscodeignore)"
             exit 1
           fi
           echo "vsix_path=vscode-extension/$VSIX" >> "$GITHUB_ENV"

--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -4,3 +4,5 @@ tsconfig.json
 jest.config.js
 coverage/
 .vscode/
+node_modules/
+


### PR DESCRIPTION
Throwaway PR to verify that the new `Verify VSIX runtime dependencies` step in #300 actually fails when `node_modules/` is excluded from the VSIX. Will close and delete after CI finishes.