### PR TITLE
chore: auto-sync webapp/uv.lock on release PRs + CI lock-drift check (#296)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,10 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
 
+      - name: Verify uv.lock
+        working-directory: webapp
+        run: uv lock --check
+
       - name: Install dependencies
         working-directory: webapp
         run: uv sync --extra dev

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,6 +23,37 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      # Release Please bumps webapp/pyproject.toml via the generic updater but
+      # has no concept of uv lockfiles. Without this, every release leaves
+      # webapp/uv.lock pinned to the previous version (see #295, #296). When a
+      # release-please PR is open, regenerate the lockfile on its branch so the
+      # release ships with a consistent state.
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Sync webapp/uv.lock on release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="release-please--branches--main"
+          if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "No active release-please branch — nothing to sync"
+            exit 0
+          fi
+          git clone --branch "$BRANCH" --depth 2 \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" release-pr
+          cd release-pr
+          (cd webapp && uv lock)
+          if git diff --quiet webapp/uv.lock; then
+            echo "uv.lock already in sync — nothing to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add webapp/uv.lock
+          git commit -m "chore: regenerate webapp/uv.lock"
+          git push origin "$BRANCH"
+
   build-release:
     name: Build & Release
     needs: release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,21 +26,20 @@ jobs:
       # Release Please bumps webapp/pyproject.toml via the generic updater but
       # has no concept of uv lockfiles. Without this, every release leaves
       # webapp/uv.lock pinned to the previous version (see #295, #296). When a
-      # release-please PR is open, regenerate the lockfile on its branch so the
-      # release ships with a consistent state.
+      # release-please PR is open or updated, regenerate the lockfile on its
+      # branch so the release ships with a consistent state.
       - uses: astral-sh/setup-uv@v7
+        if: steps.release.outputs.prs_created == 'true'
 
       - name: Sync webapp/uv.lock on release PR
+        if: steps.release.outputs.prs_created == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
         run: |
           set -euo pipefail
-          BRANCH="release-please--branches--main"
-          if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            echo "No active release-please branch — nothing to sync"
-            exit 0
-          fi
-          git clone --branch "$BRANCH" --depth 2 \
+          BRANCH=$(echo "$PR_JSON" | jq -r '.headBranchName')
+          git clone --branch "$BRANCH" --depth 2 --quiet \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" release-pr
           cd release-pr
           (cd webapp && uv lock)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,11 +293,11 @@ chore: bump @anthropic-ai/sdk to 0.52.0
 4. Release Please creates the git tag → triggers `release.yml` → builds VSIX → publishes to Marketplace
 
 ### CI Workflows
-- **`ci.yml`** — Runs on every PR: `npm test` (942 tests) + `vsce package` (catches `engines.vscode` / `@types/vscode` mismatches and `.vscodeignore` misconfig pre-merge) in `vscode-extension/`, `pytest` (799 tests) in `webapp/`
+- **`ci.yml`** — Runs on every PR: `npm test` (942 tests) + `vsce package` (catches `engines.vscode` / `@types/vscode` mismatches and `.vscodeignore` misconfig pre-merge) in `vscode-extension/`, `uv lock --check` + `pytest` (799 tests) in `webapp/` — `uv lock --check` fails the PR if `webapp/uv.lock` has drifted from `pyproject.toml`
 - **`eval.yml`** — Runs on PRs touching `shared/prompts/**`, `shared/defaults.json`, or `shared/eval/scorer.py`: scores golden set (79 CI entries / 84 total) via Anthropic API, validates schema + agreement (~$0.30/run). Skipped for Dependabot.
 - **`security-review.yml`** — Claude-powered security review via `anthropics/claude-code-security-review`. Triggered by `needs-security-review` label on PR (not on every push, to control API costs). Skipped on docs-only PRs and Dependabot. Scans webview (`media/app.js`), webapp (`webapp/`), and project Claude config (`.claude/hooks/`, `.claude/settings.json`, `.claude/agents/`).
 - **`claude-review.yml`** — AI code review via `claude-code-action@v1`. Triggered by `needs-review` label on PR (not on every push, to control API costs). Also responds to `@claude` mentions in PR comments.
-- **`release-please.yml`** — Auto-creates release PRs with changelog + version bumps from conventional commits. When a release is created, chains into a `build-release` job that builds VSIX, publishes to Marketplace, uploads to GitHub Release, and marks the release as non-draft.
+- **`release-please.yml`** — Auto-creates release PRs with changelog + version bumps from conventional commits. Auto-syncs `webapp/uv.lock` onto the release PR branch when one exists (Release Please's generic updater bumps `pyproject.toml` but not the lockfile). When a release is created, chains into a `build-release` job that builds VSIX, publishes to Marketplace, uploads to GitHub Release, and marks the release as non-draft.
 - **`release.yml`** — Manual fallback (`workflow_dispatch` only) for retrying failed releases or manual tag releases. Not triggered automatically.
 
 ## Product Development Workflow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,7 @@ Before submitting a pull request, verify:
 
 - [ ] `npm test` passes (942+ extension tests green)
 - [ ] `uv run pytest` passes (799+ webapp tests green)
+- [ ] `webapp/uv.lock` is in sync (`uv lock --check` — don't hand-edit; run `uv lock` after changing `pyproject.toml`)
 - [ ] No regressions in existing functionality
 - [ ] New features include test coverage
 - [ ] Both interfaces updated if the change affects shared functionality


### PR DESCRIPTION
## Summary
- **`release-please.yml`**: After the release-please-action step, detect whether the release-please branch exists on origin. If yes, clone fresh, run `uv lock` in `webapp/`, and push the regenerated lockfile back to the release PR branch as a `github-actions[bot]` commit. No-op when no release PR is active.
- **`ci.yml`**: Add `uv lock --check` before `uv sync` in the webapp test job. Fails the PR if `webapp/uv.lock` has drifted from `pyproject.toml`.
- Updates the CLAUDE.md CI workflow descriptions to document both gates.

## Why
Two different gaps with the same root cause — Release Please's `generic` updater bumps `webapp/pyproject.toml`'s version string but doesn't know about uv lockfiles. Without the release-side hook, every release leaves the lockfile pinned to the previous version (see #295 for the manual fix during v1.2.0). Without the CI-side check, hand-edited dependency changes can land on main with a stale lockfile.

Together they ensure the lockfile always reflects `pyproject.toml`, on every PR and at every release.

## Caveat — `GITHUB_TOKEN` push doesn't re-trigger CI

> **Resolved 2026-05-08 by #324 (closes #305).** The auto-sync step now uses `RELEASE_PLEASE_TOKEN` (fine-grained PAT) instead of `GITHUB_TOKEN`, so its push retriggers CI on the release PR. The "out of scope for this PR" follow-up below has shipped.

Commits pushed by `github-actions[bot]` don't trigger workflows by default (GitHub's loop-prevention). So the auto-sync commit on the release PR branch won't re-run CI on the release PR. The lockfile change is small and the next push (e.g., release-please's next run, or merge) will trigger CI normally. If we later want the lockfile commit to trigger CI, we can switch to a PAT — out of scope for this PR.

## Test plan
- [x] `uv lock --check` succeeds locally on current main (lockfile already in sync after #295)
- [ ] PR CI run shows the new `Verify uv.lock` step passing
- [ ] (After merge, observed at next release) When release-please opens the v1.2.1 PR, the `Sync webapp/uv.lock on release PR` step runs and either commits a lockfile bump to the release branch or logs "already in sync"

## Closes
Closes #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)