### PR TITLE
fix: Daily Token Usage chart DOM-leak + Pattern A render audit (#297)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ npm run compile            # One-shot TypeScript compilation
 npm run watch              # Continuous compilation
 
 # Test
-npm test                   # Jest (unit + integration, 942 tests)
+npm test                   # Jest (unit + integration, 962 tests)
 
 # Package and install
 npx @vscode/vsce package --allow-missing-repository
@@ -293,7 +293,7 @@ chore: bump @anthropic-ai/sdk to 0.52.0
 4. Release Please creates the git tag → triggers `release.yml` → builds VSIX → publishes to Marketplace
 
 ### CI Workflows
-- **`ci.yml`** — Runs on every PR: `npm test` (942 tests) + `vsce package` (catches `engines.vscode` / `@types/vscode` mismatches and `.vscodeignore` misconfig pre-merge) in `vscode-extension/`, `uv lock --check` + `pytest` (799 tests) in `webapp/` — `uv lock --check` fails the PR if `webapp/uv.lock` has drifted from `pyproject.toml`
+- **`ci.yml`** — Runs on every PR: `npm test` (962 tests) + `vsce package` (catches `engines.vscode` / `@types/vscode` mismatches and `.vscodeignore` misconfig pre-merge) in `vscode-extension/`, `uv lock --check` + `pytest` (799 tests) in `webapp/` — `uv lock --check` fails the PR if `webapp/uv.lock` has drifted from `pyproject.toml`
 - **`eval.yml`** — Runs on PRs touching `shared/prompts/**`, `shared/defaults.json`, or `shared/eval/scorer.py`: scores golden set (79 CI entries / 84 total) via Anthropic API, validates schema + agreement (~$0.30/run). Skipped for Dependabot.
 - **`security-review.yml`** — Claude-powered security review via `anthropics/claude-code-security-review`. Triggered by `needs-security-review` label on PR (not on every push, to control API costs). Skipped on docs-only PRs and Dependabot. Scans webview (`media/app.js`), webapp (`webapp/`), and project Claude config (`.claude/hooks/`, `.claude/settings.json`, `.claude/agents/`).
 - **`claude-review.yml`** — AI code review via `claude-code-action@v1`. Triggered by `needs-review` label on PR (not on every push, to control API costs). Also responds to `@claude` mentions in PR comments.
@@ -353,7 +353,7 @@ When implementing from a PM-produced spec or issue:
 ## Production Standards
 - **All new features must have tests.** No merging without test coverage for the change.
 - **Security:** All user-controlled strings rendered in HTML must pass through `escapeHtml()`. All shell commands must use `execFileSync` with argument arrays, never string interpolation. Error messages must pass through `_sanitize_error()` / `sanitizeError()` to redact API keys. XSS and injection tests exist and must stay green.
-- **No regressions:** `npm test` must pass (currently 942 tests) before any commit to main.
+- **No regressions:** `npm test` must pass (currently 962 tests) before any commit to main.
 - **Feature parity:** Both the VS Code extension and the webapp are production deliverables. New scoring/analytics features should be implemented in both. Security fixes (XSS, injection) apply to both `media/app.js` and `webapp/static/app.js`.
 - **E2E testing:** Every PR test plan must include manual Playwright MCP smoke testing of the webapp before merging. See the E2E Smoke Test Checklist below.
 
@@ -618,6 +618,7 @@ npm test                   # Runs all 907 Jest tests (23 suites)
 # test/unit/taskClassification.test.ts         — branch prefix mapping, keyword regex, classification priority
 # test/unit/antiPatterns.test.ts               — structured output anti-pattern detection, false positive avoidance
 # test/unit/configScanner.test.ts              — .claude/ directory scanning, frontmatter parsing, error resilience
+# test/unit/renderUsageDashboard.test.ts       — Pattern A render-function idempotency: clearEmptyState helper + call-site audits in both interfaces (JSDOM env)
 # test/integration/extension.test.ts           — activation, status bar, commands
 # test/integration/webviewProvider.test.ts      — message handling, HTML generation, injection tests, optimizer IPC
 # test/__mocks__/vscode.ts                     — VS Code API mock for Jest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,9 @@ Then open `http://localhost:8000`. See [`webapp/README.md`](webapp/README.md) fo
 
 ## Running Tests
 
-The project has **1741 automated tests** across both interfaces. All must pass before merging.
+The project has **1761 automated tests** across both interfaces. All must pass before merging.
 
-### VS Code Extension (942 tests, 23 suites)
+### VS Code Extension (962 tests, 24 suites)
 
 ```bash
 cd vscode-extension
@@ -71,6 +71,7 @@ npx jest test/unit/scoring      # Run a specific test file
 | `configScanner.test.ts` | .claude/ directory scanning, maturity scoring |
 | `extension.test.ts` | Activation, status bar, commands |
 | `webviewProvider.test.ts` | Message handling, HTML generation, injection tests, config advisor |
+| `renderUsageDashboard.test.ts` | Pattern A render-function idempotency: `clearEmptyState` helper + call-site audits in both interfaces |
 
 ### Web App (799 tests, 12 suites)
 
@@ -133,6 +134,16 @@ Example: `feat: add session token analytics to Usage tab (#89)`
 - ES6+, no semicolons, async/await
 - **No inline `onclick` handlers** — the webview uses nonce-based CSP that blocks them. Use event delegation on `document` instead.
 
+### Rendering pattern (`media/app.js`, `webapp/static/app.js`)
+
+Render functions fall into three patterns. Each new render function must use one of them:
+
+- **Pattern A** — `insertAdjacentHTML` of an `.empty-state-box` (or `.error-state-box`) plus `canvas.style.display = 'none'` for empty/error states. **Must call `clearEmptyState(container)` at the top of the function** to clear DOM mutations from prior renders. Without that call, transitioning from empty → data leaves the prior empty-state DOM stacked on top of the freshly-rendered chart (#297).
+- **Pattern B** — toggle `display` on pre-existing DOM elements via a `load*` wrapper that resets all states at the top. Catch paths must explicitly hide every section that a successful render could have shown — otherwise an in-flight `*Updated` event can re-show sections during the await, leaving stale data behind the empty-state.
+- **Pattern C** — full `container.innerHTML = ...` replacement. Inherently idempotent; no cleanup needed.
+
+Audit and rationale: [architect review on #298](https://github.com/frederick-douglas-pearce/codefluent/issues/298#issuecomment-4348482446).
+
 ### Python (webapp — `webapp/`)
 
 - Python 3.12+, type hints encouraged
@@ -192,7 +203,7 @@ CodeFluent ships **two production interfaces**: the VS Code extension and the we
 
 Before submitting a pull request, verify:
 
-- [ ] `npm test` passes (942+ extension tests green)
+- [ ] `npm test` passes (962+ extension tests green)
 - [ ] `uv run pytest` passes (799+ webapp tests green)
 - [ ] `webapp/uv.lock` is in sync (`uv lock --check` — don't hand-edit; run `uv lock` after changing `pyproject.toml`)
 - [ ] No regressions in existing functionality

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Cost: ~$0.65–0.75 per CI run on the 79-entry subset (Sonnet 4.6, includes sing
 | Input validation | Pydantic constraints, length limits, path checks | Oversized payloads, path traversal |
 | Rate limiting | 10 req/min sliding window (webapp) | API abuse |
 | CORS | Localhost-only default (webapp) | Unauthorized cross-origin access |
-| Automated testing | 1741 tests including security-focused suites | Regressions |
+| Automated testing | 1761 tests including security-focused suites | Regressions |
 | CI security review | Claude security review on PRs | New vulnerabilities |
 
 All user-controlled strings are escaped before rendering in HTML. Shell commands use argument arrays (`execFileSync`) instead of string interpolation. The webapp validates all inputs with Pydantic models and enforces rate limits. Security-focused test suites verify XSS and injection protections.
@@ -444,11 +444,11 @@ See [`webapp/README.md`](webapp/README.md) for configuration, CORS, and Windows 
 
 ### Testing
 
-The project has **1741 automated tests** across both interfaces:
+The project has **1761 automated tests** across both interfaces:
 
 ```bash
 cd vscode-extension
-npm test                   # 942 tests across 23 suites (Jest)
+npm test                   # 962 tests across 24 suites (Jest)
 
 cd webapp
 uv run pytest tests/ -v    # 799 tests across 12 suites (pytest)
@@ -460,7 +460,7 @@ Test suites cover scoring, parsing, caching, analytics, pricing, agent metrics, 
 
 Six GitHub Actions workflows run automatically:
 
-- **CI** (`ci.yml`) — Runs on every PR: compiles TypeScript, runs all 1741 tests, plus `npm audit` and `pip-audit` for dependency vulnerabilities. Must pass to merge.
+- **CI** (`ci.yml`) — Runs on every PR: compiles TypeScript, runs all 1761 tests, plus `npm audit` and `pip-audit` for dependency vulnerabilities. Must pass to merge.
 - **Eval** (`eval.yml`) — Runs on PRs that modify `shared/prompts/**`, `shared/defaults.json`, or `shared/eval/scorer.py`: scores the golden set via the Anthropic API, validates schema + agreement + task_type_agreement against human-labeled ground truth. See [Eval Framework](#eval-framework) below.
 - **Claude Code Review** (`claude-review.yml`) — AI-powered PR review on the `needs-review` label, also responds to `@claude` mentions.
 - **Security Review** (`security-review.yml`) — Claude-powered security review via [`anthropics/claude-code-security-review`](https://github.com/anthropics/claude-code-security-review), triggered by the `needs-security-review` label.

--- a/vscode-extension/media/app.js
+++ b/vscode-extension/media/app.js
@@ -397,6 +397,15 @@ function destroyChart(name) {
   }
 }
 
+// Removes any state-dependent DOM injected by a prior render of this view
+// (empty/error/loading boxes) and restores any hidden canvases. Required
+// at the top of Pattern A render functions — see CONTRIBUTING.md.
+function clearEmptyState(container) {
+  if (!container) return
+  container.querySelectorAll('.empty-state-box').forEach(el => el.remove())
+  container.querySelectorAll('canvas').forEach(c => { c.style.display = '' })
+}
+
 function showLoader(tabId) {
   document.getElementById(tabId).innerHTML =
     '<div class="scoring-loader"><div class="spinner"></div><p>Analyzing conversations with Claude...</p></div>'

--- a/vscode-extension/media/app.js
+++ b/vscode-extension/media/app.js
@@ -621,10 +621,12 @@ document.addEventListener('click', (e) => {
 
 // --- Usage Dashboard ---
 function renderUsageDashboard() {
+  const canvas = document.getElementById('usage-chart')
+  clearEmptyState(canvas?.parentElement)
+
   const daily = state.usage?.daily?.daily || []
   if (!daily.length) {
     document.getElementById('usage-pace').innerHTML = ''
-    const canvas = document.getElementById('usage-chart')
     if (canvas) {
       destroyChart('usage')
       canvas.parentElement.querySelector('h3').insertAdjacentHTML('afterend',

--- a/vscode-extension/media/app.js
+++ b/vscode-extension/media/app.js
@@ -1793,6 +1793,10 @@ async function loadConversationsExplorer() {
     } catch (_e) { /* agent metrics are supplementary */ }
   } catch (e) {
     document.getElementById('conversations-loading').style.display = 'none'
+    document.getElementById('conversations-summary-cards').style.display = 'none'
+    document.getElementById('agent-metrics-section').style.display = 'none'
+    document.getElementById('conversations-charts-row').style.display = 'none'
+    document.getElementById('conversations-table-container').style.display = 'none'
     document.getElementById('conversations-empty').style.display = ''
   }
 }

--- a/vscode-extension/media/app.js
+++ b/vscode-extension/media/app.js
@@ -343,8 +343,9 @@ async function loadData() {
     updateTimeScopeCounts()
   } catch (e) {
     console.error('Failed to load data:', e)
-    const pace = document.getElementById('usage-pace')
     const canvas = document.getElementById('usage-chart')
+    clearEmptyState(canvas?.parentElement)
+    const pace = document.getElementById('usage-pace')
     if (pace) pace.innerHTML = ''
     if (canvas) {
       canvas.style.display = 'none'

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codefluent",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codefluent",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1"
@@ -16,11 +16,12 @@
         "@types/node": "^25.6.0",
         "@types/vscode": "^1.116.0",
         "jest": "^30.3.0",
+        "jest-environment-jsdom": "^30.0.0",
         "ts-jest": "^29.4.9",
         "typescript": "^6.0.3"
       },
       "engines": {
-        "vscode": "^1.115.0"
+        "vscode": "^1.116.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -42,6 +43,27 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -548,6 +570,121 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
@@ -716,6 +853,34 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.3.0.tgz",
+      "integrity": "sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jest/expect": {
@@ -1175,6 +1340,18 @@
         "pretty-format": "^30.0.0"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
@@ -1189,6 +1366,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1491,6 +1675,16 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -1990,6 +2184,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2007,6 +2229,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -2076,6 +2305,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -2354,12 +2596,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -2369,6 +2652,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/import-local": {
@@ -2446,6 +2742,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -2769,6 +3072,29 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.3.0.tgz",
+      "integrity": "sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/environment-jsdom-abstract": "30.3.0",
+        "jsdom": "^26.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-environment-node": {
@@ -3219,6 +3545,46 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -3485,6 +3851,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3590,6 +3963,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -3717,6 +4103,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
@@ -3772,6 +4168,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -4058,6 +4481,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/synckit": {
       "version": "0.11.12",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
@@ -4135,12 +4565,58 @@
         "node": "*"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
@@ -4374,6 +4850,19 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -4382,6 +4871,54 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -4522,6 +5059,45 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -108,6 +108,7 @@
     "@types/node": "^25.6.0",
     "@types/vscode": "^1.116.0",
     "jest": "^30.3.0",
+    "jest-environment-jsdom": "^30.0.0",
     "ts-jest": "^29.4.9",
     "typescript": "^6.0.3"
   },

--- a/vscode-extension/test/unit/renderUsageDashboard.test.ts
+++ b/vscode-extension/test/unit/renderUsageDashboard.test.ts
@@ -1,0 +1,182 @@
+/**
+ * @jest-environment jsdom
+ */
+/// <reference lib="dom" />
+//
+// Regression coverage for #297 — Daily Token Usage chart DOM-leak.
+//
+// Strategy is hybrid: behavioral test of the new clearEmptyState helper
+// in isolation (extracted from the source via brace-aware regex), plus
+// source-level audits of the call-sites that must use it. We do not run
+// renderUsageDashboard directly because it depends on ~7 globals (state,
+// Chart, destroyChart, charts, renderUsagePace, formatCost, formatTokens)
+// and app.js has top-level side effects that make full-file eval brittle.
+// The source-level audit catches the regression class — "someone removed
+// the clearEmptyState call" — without requiring that whole runtime.
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+const VSCODE_APP_PATH = path.resolve(__dirname, '../../media/app.js')
+const WEBAPP_APP_PATH = path.resolve(__dirname, '../../../webapp/static/app.js')
+
+function extractClearEmptyState(filePath: string): (container: Element | null) => void {
+  const src = fs.readFileSync(filePath, 'utf-8')
+  const match = src.match(/function clearEmptyState\(container\)\s*\{[\s\S]*?\n\}/)
+  if (!match) throw new Error(`clearEmptyState not found in ${filePath}`)
+  return new Function(`return (${match[0].replace('function clearEmptyState', 'function')})`)()
+}
+
+describe('clearEmptyState() — vscode-extension', () => {
+  const clearEmptyState = extractClearEmptyState(VSCODE_APP_PATH)
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div class="card">
+        <h3>Daily Token Usage</h3>
+        <canvas id="usage-chart"></canvas>
+      </div>
+    `
+  })
+
+  test('handles null container gracefully', () => {
+    expect(() => clearEmptyState(null)).not.toThrow()
+  })
+
+  test('removes .empty-state-box children', () => {
+    const card = document.querySelector('.card')!
+    card.insertAdjacentHTML('beforeend', '<div class="empty-state-box">x</div>')
+    expect(card.querySelector('.empty-state-box')).not.toBeNull()
+    clearEmptyState(card)
+    expect(card.querySelector('.empty-state-box')).toBeNull()
+  })
+
+  test('resets hidden canvas display', () => {
+    const card = document.querySelector('.card')!
+    const canvas = document.getElementById('usage-chart') as HTMLCanvasElement
+    canvas.style.display = 'none'
+    clearEmptyState(card)
+    expect(canvas.style.display).toBe('')
+  })
+
+  test('idempotent on already-clean container', () => {
+    const card = document.querySelector('.card')!
+    clearEmptyState(card)
+    expect(() => clearEmptyState(card)).not.toThrow()
+    expect(card.querySelector('.empty-state-box')).toBeNull()
+  })
+
+  test('removes multiple .empty-state-box children if stacked', () => {
+    const card = document.querySelector('.card')!
+    card.insertAdjacentHTML('beforeend', '<div class="empty-state-box">a</div>')
+    card.insertAdjacentHTML('beforeend', '<div class="empty-state-box">b</div>')
+    clearEmptyState(card)
+    expect(card.querySelectorAll('.empty-state-box').length).toBe(0)
+  })
+
+  test('combined: removes empty-state AND restores canvas in one call', () => {
+    const card = document.querySelector('.card')!
+    const canvas = document.getElementById('usage-chart') as HTMLCanvasElement
+    canvas.style.display = 'none'
+    card.querySelector('h3')!.insertAdjacentHTML(
+      'afterend',
+      '<div class="empty-state-box">No usage data yet.</div>'
+    )
+
+    clearEmptyState(card)
+
+    expect(card.querySelector('.empty-state-box')).toBeNull()
+    expect(canvas.style.display).toBe('')
+  })
+})
+
+describe('clearEmptyState() — webapp parity', () => {
+  test('webapp app.js has identical helper signature', () => {
+    const src = fs.readFileSync(WEBAPP_APP_PATH, 'utf-8')
+    expect(src).toMatch(/function clearEmptyState\(container\)\s*\{/)
+  })
+
+  test('webapp helper has same behavior as extension version', () => {
+    const clearEmptyState = extractClearEmptyState(WEBAPP_APP_PATH)
+    document.body.innerHTML = `
+      <div class="card">
+        <canvas id="usage-chart" style="display: none"></canvas>
+        <div class="empty-state-box">stale</div>
+      </div>
+    `
+    const card = document.querySelector('.card')!
+    clearEmptyState(card)
+    expect(card.querySelector('.empty-state-box')).toBeNull()
+    expect((document.getElementById('usage-chart') as HTMLCanvasElement).style.display).toBe('')
+  })
+})
+
+describe('renderUsageDashboard() call-site audits', () => {
+  function renderUsageDashboardBody(filePath: string): string {
+    const src = fs.readFileSync(filePath, 'utf-8')
+    const match = src.match(/function renderUsageDashboard\(\)\s*\{[\s\S]*?\n\}/m)
+    expect(match).toBeTruthy()
+    return match![0]
+  }
+
+  test('vscode-extension calls clearEmptyState at top of function', () => {
+    expect(renderUsageDashboardBody(VSCODE_APP_PATH)).toMatch(/clearEmptyState\(/)
+  })
+
+  test('webapp calls clearEmptyState at top of function', () => {
+    expect(renderUsageDashboardBody(WEBAPP_APP_PATH)).toMatch(/clearEmptyState\(/)
+  })
+})
+
+describe('loadData() catch-path call-site audits', () => {
+  function loadDataCatchBlock(filePath: string): string {
+    const src = fs.readFileSync(filePath, 'utf-8')
+    const match = src.match(/} catch \(e\) \{[\s\S]*?Failed to load data[\s\S]*?\n\s*\}/m)
+    expect(match).toBeTruthy()
+    return match![0]
+  }
+
+  test('vscode-extension catch calls clearEmptyState before injecting error box', () => {
+    expect(loadDataCatchBlock(VSCODE_APP_PATH)).toMatch(/clearEmptyState\(/)
+  })
+
+  test('webapp catch calls clearEmptyState before injecting error box', () => {
+    expect(loadDataCatchBlock(WEBAPP_APP_PATH)).toMatch(/clearEmptyState\(/)
+  })
+})
+
+describe('loadConversationsExplorer() catch-path stale-data audits', () => {
+  function loadConversationsExplorerCatch(filePath: string): string {
+    const src = fs.readFileSync(filePath, 'utf-8')
+    const fnMatch = src.match(/async function loadConversationsExplorer\(\)\s*\{[\s\S]*?\n\}/m)
+    expect(fnMatch).toBeTruthy()
+    const catchMatch = fnMatch![0].match(/} catch \(e\) \{[\s\S]*?\n  \}/m)
+    expect(catchMatch).toBeTruthy()
+    return catchMatch![0]
+  }
+
+  for (const [label, filePath] of [
+    ['vscode-extension', VSCODE_APP_PATH],
+    ['webapp', WEBAPP_APP_PATH],
+  ] as const) {
+    test(`${label} catch hides conversations-summary-cards`, () => {
+      expect(loadConversationsExplorerCatch(filePath))
+        .toMatch(/conversations-summary-cards.*display\s*=\s*'none'/s)
+    })
+
+    test(`${label} catch hides agent-metrics-section`, () => {
+      expect(loadConversationsExplorerCatch(filePath))
+        .toMatch(/agent-metrics-section.*display\s*=\s*'none'/s)
+    })
+
+    test(`${label} catch hides conversations-charts-row`, () => {
+      expect(loadConversationsExplorerCatch(filePath))
+        .toMatch(/conversations-charts-row.*display\s*=\s*'none'/s)
+    })
+
+    test(`${label} catch hides conversations-table-container`, () => {
+      expect(loadConversationsExplorerCatch(filePath))
+        .toMatch(/conversations-table-container.*display\s*=\s*'none'/s)
+    })
+  }
+})

--- a/webapp/static/app.js
+++ b/webapp/static/app.js
@@ -1888,6 +1888,10 @@ async function loadConversationsExplorer() {
     } catch (_e) { /* agent metrics are supplementary */ }
   } catch (e) {
     document.getElementById('conversations-loading').style.display = 'none'
+    document.getElementById('conversations-summary-cards').style.display = 'none'
+    document.getElementById('agent-metrics-section').style.display = 'none'
+    document.getElementById('conversations-charts-row').style.display = 'none'
+    document.getElementById('conversations-table-container').style.display = 'none'
     document.getElementById('conversations-empty').style.display = ''
   }
 }

--- a/webapp/static/app.js
+++ b/webapp/static/app.js
@@ -424,6 +424,15 @@ function destroyChart(name) {
   }
 }
 
+// Removes any state-dependent DOM injected by a prior render of this view
+// (empty/error/loading boxes) and restores any hidden canvases. Required
+// at the top of Pattern A render functions — see CONTRIBUTING.md.
+function clearEmptyState(container) {
+  if (!container) return
+  container.querySelectorAll('.empty-state-box').forEach(el => el.remove())
+  container.querySelectorAll('canvas').forEach(c => { c.style.display = '' })
+}
+
 function showLoader(tabId) {
   document.getElementById(tabId).innerHTML =
     '<div class="scoring-loader"><div class="spinner"></div><p>Analyzing conversations with Claude...</p></div>'

--- a/webapp/static/app.js
+++ b/webapp/static/app.js
@@ -369,8 +369,9 @@ async function loadData() {
     updateTimeScopeCounts()
   } catch (e) {
     console.error('Failed to load data:', e)
-    const pace = document.getElementById('usage-pace')
     const canvas = document.getElementById('usage-chart')
+    clearEmptyState(canvas?.parentElement)
+    const pace = document.getElementById('usage-pace')
     if (pace) pace.innerHTML = ''
     if (canvas) {
       canvas.style.display = 'none'

--- a/webapp/static/app.js
+++ b/webapp/static/app.js
@@ -661,10 +661,12 @@ document.addEventListener('click', (e) => {
 
 // --- Usage Dashboard ---
 function renderUsageDashboard() {
+  const canvas = document.getElementById('usage-chart')
+  clearEmptyState(canvas?.parentElement)
+
   const daily = state.usage?.daily?.daily || []
   if (!daily.length) {
     document.getElementById('usage-pace').innerHTML = ''
-    const canvas = document.getElementById('usage-chart')
     if (canvas) {
       destroyChart('usage')
       canvas.parentElement.querySelector('h3').insertAdjacentHTML('afterend',


### PR DESCRIPTION
## Summary

Closes #297 — Daily Token Usage chart stays hidden after a transient empty render. Lands as v1.2.1 patch.

Five focused commits in one PR (architect-recommended scope from [#298 review](https://github.com/frederick-douglas-pearce/codefluent/issues/298#issuecomment-4348482446)):

1. \`refactor: add clearEmptyState helper to both frontends\` — pure helper introduction in \`media/app.js\` + \`webapp/static/app.js\`
2. \`fix(usage): make renderUsageDashboard idempotent (#297)\` — applies helper in both interfaces. **This is the user-visible bug fix.**
3. \`fix(usage): clear stale state in loadData catch path (#297)\` — same idempotency principle for the error path
4. \`fix(conversations): hide stale data sections in catch path (#297)\` — architect-flagged secondary fix; closes a \`conversationsUpdated\` IPC race in \`loadConversationsExplorer\`
5. \`test: add Jest+JSDOM regression tests + rendering-pattern docs (#297)\` — 20 new tests + \`CONTRIBUTING.md\` Pattern A/B/C convention + test-count updates

## Why this fix

\`renderUsageDashboard()\`'s empty branch inserts a \`.empty-state-box\` after the chart's \`<h3>\` and sets \`canvas.style.display = 'none'\`. Subsequent calls with real data create a \`Chart.js\` instance on the canvas — but the canvas is still hidden and the empty-state DOM is still in place. User sees pace cards (re-rendered via \`innerHTML\`) but the chart appears empty. Triggered by transient \`ccusage daily\` failures (timeout, parse error). Long-standing bug; surfaced in v1.2.0.

\`clearEmptyState(container)\` removes any \`.empty-state-box\` children and resets any hidden canvas. Called at the top of every Pattern A render function before deciding empty/data/error state, it makes the function idempotent.

## Test plan

- [x] \`npm test\` passes locally — **962 tests across 24 suites** (added 20 from new test file)
- [x] New test file exercises empty → data → empty transitions on \`clearEmptyState\` directly + source-level audits assert all three call-sites contain the helper invocation in both interfaces + audits the \`loadConversationsExplorer\` catch for all four \`display:none\` lines
- [x] CI green on this PR (Run Tests + Run Webapp Tests + Verify uv.lock + Package VSIX + Verify VSIX runtime dependencies)
- [ ] Manual smoke test post-merge (cannot be automated — bug requires real ccusage failure):
  1. Build VSIX, install, reload VS Code window
  2. Open Usage tab → confirm chart renders with data
  3. Force ccusage daily failure (rename / disable npx briefly), click Refresh → confirm "No usage data yet" appears
  4. Restore ccusage, click Refresh → **chart must reappear** (pre-fix: stays hidden)

## Out of scope (deferred)

- **Fix C (partial-failure messaging)** — \`getUsageData()\` returning a richer shape that distinguishes "daily failed" from "no data yet" — different review surface, defer to v1.3
- **Webapp Vitest+JSDOM** — architect's broader test-infra recommendation in #298, deferred to v1.3
- **Pattern audit redo** — architect already did the audit in #298 comment; \`CONTRIBUTING.md\` references it
- **Lint guardrail / grep CI gate** — defer to #298

## Architect review

The implementation follows the design from the architect's [#298 review comment](https://github.com/frederick-douglas-pearce/codefluent/issues/298#issuecomment-4348482446). The hybrid test strategy (direct unit test of \`clearEmptyState\` + source-level audits of the call-sites in both interfaces) was Plan-agent-validated as the right balance between behavioral coverage and v1.2.1 scope discipline.

## Closes

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)