### PR TITLE
fix: prevent Dependabot drift between @types/vscode and engines.vscode (#293)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    ignore:
+      # @types/vscode must stay aligned with engines.vscode (vsce package
+      # enforces @types/vscode <= engines.vscode). Bump both together by hand
+      # when raising the VS Code floor — see CONTRIBUTING.md.
+      - dependency-name: "@types/vscode"
     groups:
       npm-patch-minor:
         update-types:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -584,6 +584,7 @@ Fixed brand colors (semantic meaning, don't change with theme):
 4. **No authentication** — Runs locally, no login
 5. **node_modules must be in VSIX** — `.vscodeignore` must NOT exclude `node_modules/` (the Anthropic SDK is a runtime dependency)
 6. **`onView:` activation event required** — Without it in `package.json`, the extension won't activate when the sidebar opens
+7. **`@types/vscode` and `engines.vscode` must move together** — `vsce package` enforces `@types/vscode` ≤ `engines.vscode`. `@types/vscode` is exact-pinned and Dependabot-ignored; bump both fields in the same commit when raising the VS Code floor (see CONTRIBUTING.md)
 
 ## When Stuck
 - If extension doesn't activate, check `activationEvents` in `package.json` includes `onView:codefluent.dashboard`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,16 @@ Example: `feat: add session token analytics to Usage tab (#89)`
 - **ES2020 target**, CommonJS output
 - Keep files under ~300 lines; split when they grow beyond that
 
+### VS Code API compatibility (`@types/vscode` and `engines.vscode`)
+
+`vsce package` enforces `@types/vscode` ≤ `engines.vscode`. The two must stay aligned, but only one is an npm dependency — Dependabot can bump `@types/vscode` and has no awareness of `engines.vscode`. To prevent silent drift (which previously blocked the v1.2.0 release):
+
+- `@types/vscode` is **exact-pinned** in `vscode-extension/package.json` (no caret, no tilde)
+- Dependabot **ignores** `@types/vscode` via `.github/dependabot.yml`
+- The pre-merge `vsce package` step in `ci.yml` is the safety net
+
+**When raising the VS Code floor** (the only legitimate reason to bump either field), update both `engines.vscode` and `@types/vscode` to the same version in the **same commit**. Never bump one without the other.
+
 ### JavaScript (webview — `media/app.js`, `webapp/static/app.js`)
 
 - ES6+, no semicolons, async/await

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/node": "^25.6.0",
-        "@types/vscode": "^1.116.0",
+        "@types/vscode": "1.116.0",
         "jest": "^30.3.0",
         "jest-environment-jsdom": "^30.0.0",
         "ts-jest": "^29.4.9",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -106,7 +106,7 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^25.6.0",
-    "@types/vscode": "^1.116.0",
+    "@types/vscode": "1.116.0",
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.0.0",
     "ts-jest": "^29.4.9",


### PR DESCRIPTION
## Summary

- Pin `@types/vscode` to exact version `1.116.0` (no caret) in `vscode-extension/package.json`
- Add Dependabot `ignore` rule for `@types/vscode` in `.github/dependabot.yml`
- Document the joint-bump rule in `CONTRIBUTING.md` (new "VS Code API compatibility" subsection) and `CLAUDE.md` (new Critical Constraint #7)

## Why

`vsce package` enforces `@types/vscode` ≤ `engines.vscode`, but only `@types/vscode` is a real npm dependency — `engines.vscode` is metadata. Dependabot has bumped `@types/vscode` independently twice already, both times silently:

- #233 / commit 3cfb4b9 → drift → fixed
- #275 → drift → caught only at v1.2.0 release time, fixed in PR #291

CI's pre-merge `vsce package` check (#299) is the safety net; this change is the prevention. After this lands, `@types/vscode` only changes when a human deliberately raises the VS Code floor and bumps both fields in the same commit.

Closes #293.

## Why not group them in Dependabot?

Grouping doesn't fix this — Dependabot can't edit `engines.vscode` (it's metadata, not a dependency). The only durable fix is to keep Dependabot out of `@types/vscode` entirely.

## Test plan

- [x] `npm install` succeeds, lockfile resolves to exactly `1.116.0`
- [x] `npm test` — 962 tests pass
- [x] `npm run compile` — clean
- [x] `npx @vscode/vsce package` — succeeds (1.67 MB VSIX)
- [x] CI green on PR
- [ ] After merge: monitor Dependabot for one cycle to confirm no `@types/vscode` PR is opened

## Files

- `vscode-extension/package.json` — exact pin
- `vscode-extension/package-lock.json` — regenerated
- `.github/dependabot.yml` — ignore rule for `@types/vscode`
- `CLAUDE.md` — Critical Constraint #7 added
- `CONTRIBUTING.md` — new "VS Code API compatibility" subsection under Code Conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)