### PR TITLE
docs: v1.3 'Mastery' PRD and decision log entries

### DIFF
--- a/.claude/specs/decisions.md
+++ b/.claude/specs/decisions.md
@@ -137,3 +137,77 @@
 **Epic milestone strategy:** Epics #176 and #174 follow their remaining stories to v1.3. The milestone field tracks "when will this close," not "when did planning start." Both epics had significant v1.2 work shipped (closed issues stay on v1.2 milestone).
 
 **Impact:** v1.2 milestone can be closed after PR #230 merges (0 open issues remaining). v1.3 gains 6 issues (now 23 open). v1.3 has a natural shape: interaction quality completion + ccusage phase-out + subagent analytics.
+
+## 2026-04-30: v1.3 Scope Decisions
+
+**Context:** PM agent scoped v1.3 "Mastery" release. 27 issues on the milestone, no PRD. Solo maintainer; target ~6 weeks of work (matching v1.2 cadence).
+
+### Decision 10: Epic 5 scoped to 5a only (radar + aggregation)
+
+**Options considered:**
+- A) Full Epic 5 (XL) — radar, agentic patterns, context efficiency, cost insights, CCA recommendations, parser enhancement
+- B) Epic 5a only (L) — radar chart + aggregation + CCA-aligned recommendations + parser enhancement (#160)
+- C) Skip Epic 5 entirely, focus on completing deferred v1.2 stories + agent analytics
+
+**Decision:** Option B (5a only)
+
+**Rationale:** Full Epic 5 is XL and would consume the entire release budget. 5a delivers the marquee feature (CCA radar) by aggregating data already computed by Epics 1-4. Deeper detection (agentic patterns, context efficiency) and cost insights are deferred to v2.0 as part of 5b. The parser enhancement (#160) is pulled in because it feeds data to the radar (compact_count, hook execution stats).
+
+**Impact:** v1.3 includes CCA radar chart, CCA-aligned recommendations, and parser enhancement (#160). Deeper Epic 5 features (token bloat detection, cost ROI, advanced agentic patterns) move to v2.0.
+
+### Decision 11: Epic 6 partial — only #115 and #116
+
+**Options considered:**
+- A) Full Epic 6 (all 5 stories: #112-#116)
+- B) #115 (confidence) + #116 (user feedback) only
+- C) Defer all of Epic 6
+
+**Decision:** Option B (#115 + #116 only)
+
+**Rationale:** #112 (multi-provider eval), #113 (human review loop), and #114 (cross-model agreement) all depend on having a second LLM provider integrated, which doesn't exist. Building infrastructure without a consumer is speculative engineering. #115 and #116 deliver standalone value: confidence calibration improves scoring transparency, user feedback enables golden set growth from real users.
+
+**Impact:** Three stories (#112, #113, #114) defer to v2.0. Epic 6 tracking issue (#178) stays open — it closes when all 5 stories ship. v1.3 ships two scoring quality improvements that are immediately useful.
+
+### Decision 12: Defer #209 (rules generation) and #298 (frontend hardening)
+
+**Context:** Both are on v1.3 milestone but don't belong to any v1.3 epic. #209 is a new LLM-powered feature; #298 is a pattern-level refactor prompted by a v1.2.1 bug fix.
+
+**Decision:** #209 to v2.0; #298 to backlog.
+
+**Rationale:** #209 (rules generation) is scope-creep — it's an LLM-powered config generation feature unrelated to the v1.3 themes (CCA radar, interaction quality, agent analytics). It also depends on #199 (multi-level tabs) for UI placement. #298 (frontend rendering hardening) is good hygiene but the targeted fix already shipped in v1.2.1; the structural rewrite can happen incrementally as render functions are added or modified.
+
+**Impact:** v1.3 milestone shrinks by 2 issues. Both remain tracked for future work.
+
+### Decision 13: #256 (subagent error recovery) is a stretch goal
+
+**Context:** #256 depends on #255 (subagent parser), which is itself a Large story. If #255 completes late in the release, #256 may not fit.
+
+**Decision:** Mark #256 as stretch. If #255 completes by Week 6, implement #256. Otherwise defer to v1.3.x or v2.0.
+
+**Rationale:** #256 reuses the error recovery algorithm from #245 — the implementation is modest. But its dependency (#255) is the risk. Declaring it stretch up front prevents pressure to rush #255 and lets the team ship without it if needed.
+
+**Impact:** No issue changes. PRD documents the stretch designation. #256 is the first thing cut if velocity slips.
+
+### Decision 14: Close Epic 2 (#174)
+
+**Context:** Epic 2 (Task Classification) had two phases. Phase A (heuristic) shipped v1.1. Phase B (LLM) shipped v1.2. The only remaining child issue is #248 (task-type normalization), which is labeled `epic:task-classification` + `epic:interaction-quality` and is functionally an Epic 4 completion story.
+
+**Decision:** Close #174. #248's primary value is normalizing interaction quality metrics — it belongs to Epic 4.
+
+**Rationale:** Keeping #174 open for a single cross-labeled story creates tracking confusion. The epic's deliverables (heuristic classification, LLM classification, golden set expansion, eval check) are all complete.
+
+**Impact:** #174 closed 2026-04-30. #248 tracked solely under Epic 4 (#176). Retains `epic:task-classification` label for traceability.
+
+### Decision 15: v1.3 PRD finalized (2026-04-30)
+
+**Context:** Human answered 5 open questions from the draft PRD. All resolutions applied.
+
+**Resolutions:**
+
+- **Q1 (Epic 2 closure):** #174 closed. All children shipped; #248 reassigned to Epic 4.
+- **Q2 (#255/#256 placement):** #255 placed in Epic 4 (subagent parsing is a dependency for Epic 4 agent analytics stories #239, #240). #256 moved to Epic 5b / v2.0 (feeds Agentic Architecture radar axis; stretch goal risk eliminated by deferring).
+- **Q3 (#199 multi-level tabs):** Deferred. Human: "functionality over UI/UX." Revisit if 8+ tabs becomes a real UX problem.
+- **Q4 (Epic 5 split):** Epic 5a (#306) created for v1.3: radar chart + aggregation + recommendations + parser #160. #177 narrowed to Epic 5b for v2.0: deeper detection + cost insights + #256. No Epic 5c needed.
+- **Q5 (#251 ccusage removal):** Full removal committed. JSONL token data is more accurate. Prior research exists. Marquee technical improvement for v1.3.
+
+**Impact:** PRD status changed from Draft to Approved. Epic 5a tracking issue #306 created. #177 scope narrowed via comment. #256 deferred from v1.3 stretch to v2.0/Epic 5b.

--- a/.claude/specs/prd-v1.3-mastery.md
+++ b/.claude/specs/prd-v1.3-mastery.md
@@ -1,0 +1,184 @@
+# PRD: v1.3 "Mastery"
+
+**Status:** Approved
+**Author:** PM Agent
+**Date:** 2026-04-30
+**Milestone:** v1.3
+**Epics:** #176 (Interaction Quality, completion), #306 (Epic 5a: CCA Radar + Aggregation), #178 (Scoring Quality Infrastructure, partial)
+
+---
+
+## Problem Statement
+
+CodeFluent v1.2 shipped scoring prompt v2.1, error recovery detection, command adoption metrics, and eval framework expansion. Four gaps remain:
+
+1. **Scoring is one-dimensional.** Users get a single Prompt Fluency score. The CCA exam tests across 5 domains (Prompt Engineering, Claude Code Config, Agentic Architecture, Tool Design & MCP, Context Management). CodeFluent cannot assess or coach users across these dimensions.
+2. **Interaction quality is incomplete.** v1.2 shipped error recovery (#245) and commands (#218) but deferred verification behaviors (#246), learning trajectory (#247), task-type normalization (#248), and behavior-token breakdown (#101).
+3. **Agent analytics are absent.** Subagent JSONL traces exist (discovered 2026-04-15) but are unparsed. Users get no insight into agent utilization, cost, error rates, or optimization opportunities.
+4. **Scoring quality has no guardrails.** No confidence calibration, user feedback signal, or cross-model validation. The eval framework exists but doesn't yet support multi-provider comparison.
+5. **Usage data depends on ccusage.** Pace/chart data is global, not project-scoped (#251). ccusage has known bugs and is an external dependency. JSONL files contain the same token data natively.
+
+## Theme
+
+**Mastery**: multi-dimensional CCA readiness scoring, completed interaction quality metrics, subagent trace analytics, ccusage removal, and scoring quality infrastructure.
+
+## Success Criteria
+
+| Criterion | Measure |
+|-----------|---------|
+| CCA readiness radar ships | 5-axis radar chart displayed with aggregated scores from existing + new data |
+| Interaction quality complete | All 4 deferred v1.2 stories (#246, #247, #248, #101) shipped |
+| Subagent parser works | Subagent JSONL traces parsed with tool breakdown, error rates, token usage |
+| Agent config scanning | `.claude/agents/` scanned and reflected in config maturity score |
+| Confidence calibration | Scoring output includes per-behavior confidence levels |
+| User feedback mechanism | Flag button on behavior scores, local storage, export capability |
+| ccusage dependency removed | Usage data sourced entirely from JSONL files; ccusage no longer called |
+| Usage tab scoped | Pace cards and chart scoped to selected project |
+| Both interfaces | All features in VS Code extension AND webapp |
+
+## Scope
+
+### Epic 4 Completion: Interaction Quality (deferred from v1.2)
+
+| Issue | Title | Priority | Size | Notes |
+|-------|-------|----------|------|-------|
+| #246 | Verification behaviors via tool sequence analysis | P0 | M | New module, heuristic, no API cost |
+| #247 | Learning trajectory + behavior acquisition curve | P0 | M | Computed from cached scores, marquee feature |
+| #248 | Task-type normalization with contextual display | P1 | M | Depends on v1.2 LLM task_type. Reassigned from Epic 2 (closed). |
+| #101 | Behavior-token breakdown table | P1 | M | Data pipeline gap (fluency_behaviors not in enriched sessions) |
+| #255 | Parse subagent JSONL trace files | P1 | L | Foundation for detailed agent analytics. Parser dependency for #239 enrichment. |
+| #176 | Epic 4 tracking issue | -- | -- | Close when all stories done |
+
+### Epic 5a: CCA Radar + Aggregation (#306)
+
+| Issue | Title | Priority | Size | Notes |
+|-------|-------|----------|------|-------|
+| #306 | Epic 5a tracking issue | -- | -- | Split from #177 (Epic 5b, v2.0) |
+| TBD | CCA readiness radar chart (5-axis) | P0 | L | Aggregates existing scores + metrics + config maturity. Chart.js radar. |
+| #160 | Parser enhancement (progress/system messages) | P1 | L | Unlocks /compact detection, hook execution counting, turn duration. Feeds radar. |
+| TBD | CCA-aligned recommendations | P1 | M | Map existing recommendations to CCA domains |
+
+### Agent Trace Analytics (Epic 4 scope)
+
+| Issue | Title | Priority | Size | Notes |
+|-------|-------|----------|------|-------|
+| #238 | Scan .claude/agents/ for subagent definitions | P0 | S | Extends config scanner. Prerequisite for #239. |
+| #239 | Track subagent invocations + metadata | P0 | L | Parser + conversation assembly + agent metrics enrichment |
+| #240 | Agent-aware recommendations | P1 | M | Rule-based, no LLM. Depends on #238 + #239. |
+
+### Epic 6 (partial): Scoring Quality Infrastructure
+
+| Issue | Title | Priority | Size | Notes |
+|-------|-------|----------|------|-------|
+| #115 | Confidence calibration | P1 | M | Scoring prompt change, eval regression test |
+| #116 | User feedback signal | P1 | M | UI + local storage + export. Both interfaces. |
+
+### Bug Fixes & Hardening
+
+| Issue | Title | Priority | Size | Notes |
+|-------|-------|----------|------|-------|
+| #251 | Usage tab project scoping (full ccusage removal) | P0 | L | Replace all ccusage calls with JSONL-derived token aggregation. Removes external dependency. Selling point: more accurate usage tracking. Prior research: PR #261 (closed #260) — message-ID dedup per Anthropic Agent SDK cost-tracking docs, with quantitative ccusage comparison and root-cause analysis of ccusage's first-wins output undercounting + subagent exclusion bugs. Foundational dedup work in PR #253 (closed #252) and subagent inclusion in PR #259 (closed #254). |
+| #294 | Update CLAUDE.md E2E checklist | P0 | S | Doc fix, 10 minutes |
+| #290 | Fix Jest tsconfig LSP errors | P2 | S | Editor-only, low severity |
+| #293 | Prevent Dependabot @types/vscode drift | P0 | S | Pin + ignore rule. Prevents repeat release blockers. |
+| #305 | Release-please PAT for CI trigger | P1 | S | One-time setup, prevents manual close/reopen on releases |
+
+---
+
+## Stretch Goals (cut first if velocity slips)
+
+1. **#101 -- Behavior-token breakdown table.** Has a data pipeline gap (need to thread `fluency_behaviors` through enriched session data). Not blocking any other story. Can ship in a v1.3.x patch if needed.
+
+## Defer List (remove from v1.3 milestone)
+
+| Issue | Title | Recommendation | Reason |
+|-------|-------|---------------|--------|
+| #112 | Multi-provider eval framework | **v2.0** | No second provider exists. Building the framework without a consumer is speculative. |
+| #113 | Human review loop | **v2.0** | "Longer term" per its own description. Depends on #112. Golden set is currently maintainer-curated and that works. |
+| #114 | Cross-model agreement testing | **v2.0** | Explicitly "becomes relevant when a second LLM provider is integrated." No second provider. |
+| #209 | Rules recommendation and generation | **v2.0** | Scope-creep. LLM-powered feature unrelated to v1.3 core themes. |
+| #298 | Frontend rendering hardening | **Backlog** | Pattern-level refactor. v1.2.1 shipped the targeted fix. The structural rewrite is valuable but not v1.3-critical. |
+| #199 | Multi-level tab layout | **Defer** | Functionality over UI/UX. If 8+ tabs becomes a real UX problem, revisit in v1.3.x or v1.4. |
+| #256 | Subagent error recovery | **v2.0 (Epic 5b)** | Depends on #255. Stretch goal that risks pulling scope. Moved to Epic 5b (#177). |
+| #174 | Epic 2: Task Classification (tracking) | **Closed** | Phase A shipped v1.1, Phase B shipped v1.2. #248 reassigned to Epic 4. |
+
+### Defer rationale: Epic 6 partial scope
+
+Full Epic 6 has 5 stories (#112-#116). Three depend on multi-provider support that doesn't exist yet. Only #115 (confidence calibration) and #116 (user feedback) deliver standalone value today. Shipping those two gives users scoring transparency and a feedback mechanism; the infrastructure stories (#112, #113, #114) wait for a real consumer.
+
+### Defer rationale: #199 (multi-level tabs)
+
+Human preference: "functionality over UI/UX." The CCA radar adds a 7th tab. If the tab bar proves unusable at that count, it can be addressed in a v1.3.x patch or v1.4. The effort is better spent on analytical features.
+
+## Orphan Triage
+
+Every issue currently on v1.3 that isn't in the scope table above:
+
+| Issue | Title | Current Labels | Recommendation |
+|-------|-------|---------------|----------------|
+| #298 | Frontend rendering hardening | quality, testing | Defer to backlog (see above) |
+| #209 | Rules recommendation/generation | feature | Defer to v2.0 (see above) |
+| #199 | Multi-level tab layout | feature | Defer (see above) |
+| #294 | CLAUDE.md E2E checklist update | documentation | **Keep in v1.3**, P0, S (trivial doc fix) |
+| #293 | Dependabot @types/vscode drift | quality, dependencies | **Keep in v1.3**, P0, S (prevents release blockers) |
+| #290 | Jest tsconfig LSP fix | (no labels) | **Keep in v1.3**, P2, S (editor annoyance, easy fix) |
+| #305 | Release-please PAT | quality, dependencies | **Keep in v1.3**, P1, S (one-time CI fix) |
+
+## Dependencies and Sequencing
+
+```
+Phase 1 -- Quick wins (Week 1-2)
+  #294, #293, #305, #290          (doc + CI fixes, unblock future releases)
+  #238                             (agent config scanning, S, unblocks #239)
+  #246                             (verification behaviors, independent)
+
+Phase 2 -- Core analytics (Week 3-5)
+  #251                             (ccusage removal, unblocks scoped usage)
+  #239                             (agent invocations, depends on #238)
+  #247                             (learning trajectory, independent)
+  #160                             (parser enhancement, unblocks CCA radar data)
+  #115                             (confidence calibration)
+
+Phase 3 -- CCA + Agent depth (Week 5-7)
+  CCA radar chart                  (aggregates #238 + #160 + existing metrics)
+  #248                             (task-type normalization)
+  #255                             (subagent parser, L)
+  #240                             (agent recommendations, depends on #238 + #239)
+  #116                             (user feedback, independent)
+  CCA-aligned recommendations
+
+Phase 4 -- Stretch (Week 7-8, if velocity allows)
+  #101                             (behavior-token breakdown)
+```
+
+### Critical path
+
+```
+#238 --> #239 --> #240
+                  |
+#160 ----------> CCA radar chart
+                  |
+#255 ----------> (enriches #239, #240; #256 deferred to v2.0)
+```
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Epic 5 is XL -- scope creep | Release drags past 6 weeks | Only 5a (radar + aggregation) is in scope (#306). 5b (deeper detection, cost insights) is explicitly v2.0 (#177). |
+| #255 (subagent parser) is complex | Delays agent analytics enrichment | #239 captures metadata from parent session tool_results without needing #255. Ship #239 first; #255 is P1 and enriches but doesn't block. |
+| Scoring prompt change for #115 | Eval regression risk | Run full eval suite. Keep v2.1 prompt as rollback. Confidence field is additive (doesn't change behavior scoring). |
+| #251 ccusage removal is marquee technical change | Data gaps, regression in usage metrics | Research already done — see PR #261 comparison table: ccusage's input-token overcounting and output-token undercounting (first-wins bug) are documented; JSONL message-ID dedup is the canonical approach per Anthropic docs. Build aggregation functions with unit tests pinning expected category-level totals. |
+| 20+ issues for solo maintainer | Overload | Aggressive stretch goal cuts. P2 items can slip to v1.3.x patches. #101 is stretch, #256 is deferred. |
+
+## Resolved Questions
+
+**Q1 -- Epic 2 (#174) closure.** Approved. #174 closed with comment. All Phase A and Phase B stories shipped. #248 reassigned to Epic 4, retains `epic:task-classification` label for traceability.
+
+**Q2 -- Epic 4 vs Epic 5 placement for #255 and #256.** #255 placed in Epic 4 (parsing subagent data is a dependency for other Epic 4 agent analytics stories). #256 moved to Epic 5b / v2.0 (feeds Agentic Architecture radar axis more than interaction quality; depends on #255 which is already complex; stretch goal risk eliminated by deferring).
+
+**Q3 -- Multi-level tabs #199.** Deferred. Human preference: "functionality over UI/UX." Revisit if 8+ tabs becomes a real problem.
+
+**Q4 -- Epic 5 split.** Split into Epic 5a (#306, v1.3: radar + aggregation + recommendations + parser #160) and Epic 5b (#177 narrowed, v2.0: deeper detection + cost insights + #256). No Epic 5c needed -- agent trace stories stay under Epic 4.
+
+**Q5 -- #251 ccusage scope.** Full removal committed. JSONL files contain native token data that is more accurate than ccusage. Prior research confirms data availability. This is a selling point for v1.3: "more accurate token usage tracking."


### PR DESCRIPTION
## Summary

Captures the v1.3 release scoping work done with the PM agent:

- **`.claude/specs/prd-v1.3-mastery.md`** (new) — full PRD covering scope, stretch goals, defer list, orphan triage, dependencies, sequencing, risks, and resolved questions
- **`.claude/specs/decisions.md`** (appended) — Decisions 10-15 documenting the calls made

## Why now

Milestone changes and the new Epic 5a tracking issue (#306) are already live in GitHub, but the canonical record of *why* those decisions were made was sitting uncommitted. Landing this now means future agents/sessions can find it via `git log` rather than relying on session memory.

## Key decisions captured

- **Epic 5 split:** scoped to 5a (radar + aggregation, #306) for v1.3; 5b (deeper detection + cost insights) deferred to v2.0 via narrowed #177
- **Epic 6 partial:** ship #115 (confidence calibration) + #116 (user feedback) only; defer #112-#114 to v2.0 pending a real second-provider consumer
- **#255 / #256 placement:** #255 (subagent parser) firmly in Epic 4; #256 (subagent error recovery) deferred to v2.0/Epic 5b
- **#199 (multi-level tabs):** deferred — functionality over UI/UX
- **#251 (full ccusage removal):** committed; research is in PR #261 (closed #260) which documents the message-ID dedup approach and quantifies ccusage's first-wins output undercounting and subagent exclusion bugs
- **#174 (Epic 2 tracking):** closed — Phase A shipped v1.1, Phase B shipped v1.2, #248 reassigned to Epic 4
- **#97 (token validation research):** closed as superseded by PR #261

## Companion changes already live

- Issue #306 created (Epic 5a: CCA Radar + Aggregation), labeled and milestoned to v1.3
- #177 milestone moved to v2.0; comment posted narrowing scope to Epic 5b
- #256 milestone moved to v2.0
- #112, #113, #114, #199, #209, #298 — milestones removed (deferred to v2.0 or backlog)
- #174 closed with explanatory comment
- #97 closed as superseded

## Test plan

- [x] No code changes — docs only
- [x] PRD format follows existing v1.2 PRD style
- [x] Decision log entries appended (not rewritten)
- [x] All issue references resolve (verified each #306, #177, #256, #261, #97, #174 exists in correct state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)