### PR TITLE
docs: refresh E2E smoke checklist for v1.2 UI (#294)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -647,11 +647,13 @@ uv run pytest tests/ -v    # Runs all webapp tests (799 tests, 12 suites)
 
 Run before merging PRs that touch webapp UI or API. Start the server with `uv run uvicorn main:app --port 8001`, then verify:
 
-1. **Tab navigation** — all 6 tabs switch correctly, correct panel is visible
-2. **Settings bar visibility** — data path input shows only on Fluency Score; project dropdown shows on Fluency Score, Optimizer, Quick Wins, Usage, Conversations; settings bar hidden on Recommendations
+1. **Tab navigation** — all 7 tabs switch correctly, correct panel is visible
+2. **Settings bar visibility** — data path input shows only on Fluency Score; project dropdown shows on Fluency Score, Conversations, Config, Optimizer, Quick Wins, Usage; settings bar hidden on Recommendations
 3. **Project dropdown** — populates from session data when data path is set
-4. **Fluency scoring** — Run Scoring button triggers analysis, results display with score ring and behavior bars
-5. **Prompt Optimizer** — paste prompt, click Optimize, input/output scores and optimized prompt appear
-6. **Quick Wins** — Generate button works; project-scoped mode uses selected project
-7. **Usage tab** — data renders with pace cards and chart (if ccusage data exists); conversation analytics section shows efficiency cards, cost-efficiency scatter charts, and sortable conversation details table; project dropdown filters conversation data
-8. **Health endpoint** — `GET /health` returns status, version, and dependency checks
+4. **Fluency scoring** — Run Analysis button triggers analysis, results display with score ring and behavior bars
+5. **Conversations tab** — summary cards, agent metrics cards (tool diversity, plan mode, cache hit, etc.), task-type pie chart, conversations-per-week chart, length/duration/gap distributions, sortable conversation list
+6. **Config tab** — configuration maturity score and breakdown render for the selected project
+7. **Prompt Optimizer** — paste prompt, click Optimize, input/output scores and optimized prompt appear
+8. **Quick Wins** — Generate button works; project-scoped mode uses selected project
+9. **Usage tab** — pace cards and Daily Token Usage chart render (if ccusage data exists); conversation analytics section shows efficiency cards, cost-efficiency scatter charts, and sortable conversation details table; project dropdown filters conversation data
+10. **Health endpoint** — `GET /health` returns status, version, and dependency checks


### PR DESCRIPTION
## Summary

Brings the manual Playwright MCP smoke checklist in `CLAUDE.md` up to date with the v1.2 webapp UI.

## Changes

- **Item 1:** tab count `6` → `7` (Config tab added in v1.1)
- **Item 2:** project-dropdown list now includes Config and is reordered to match the actual nav order in `webapp/static/index.html` (Fluency Score, Conversations, Config, Optimizer, Quick Wins, Usage)
- **Item 4:** button label `Run Scoring` → `Run Analysis` (current text in `index.html:86`)
- **New item 5 — Conversations tab:** summary cards, agent metrics cards (tool diversity, plan mode, cache hit, etc.), task-type pie chart, conversations-per-week chart, length/duration/gap distributions, sortable conversation list
- **New item 6 — Config tab:** configuration maturity score and breakdown
- Items 7–10 are the previous items 5–8 renumbered

Net: 8 → 10 items. The two new items address AC #4 ("No other stale items") — without them the smoke test doesn't exercise two of the seven tabs (Conversations + Config), where v1.1's marquee features live.

## Why this fix is needed

Two mismatches surfaced during the v1.2.0 post-release smoke test (per the issue body). Neither is a behavioral regression — the UI is correct. The doc just hasn't kept up.

## Acceptance criteria (from #294)

- [x] CLAUDE.md tab count says 7
- [x] CLAUDE.md project-dropdown list includes Config
- [x] Tab order in the checklist matches the actual nav order in the webapp
- [x] No other stale items in the E2E checklist (also updated "Run Scoring" → "Run Analysis" and added Conversations + Config items)

## Test plan

- [x] Verified actual tab order in `webapp/static/index.html` (lines 43–49)
- [x] Verified button label in `webapp/static/index.html` line 86
- [x] Verified Conversations tab structure (lines 171–212): summary cards, agent metrics, charts, table
- [x] Verified Config tab existence (line 46)
- [x] CI green (npm test + pytest run as sanity, no behavioral changes expected)

## Follow-up

There is **no open issue** for actually automating this checklist via Playwright. The closest match was #69 (closed in the v0.2.0 era, only delivered the `/health` endpoint, not E2E automation). Will file a follow-up issue once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)