### PR TITLE
docs: add E2E test automation (#312) to v1.3 scope

### DIFF
--- a/.claude/specs/decisions.md
+++ b/.claude/specs/decisions.md
@@ -52,15 +52,15 @@
 
 ### Decision 5: Agent invocation tracking (#239) should capture metadata block
 
-**Context:** Analysis of PM agent JSONL data (April 14) revealed that subagent `tool_result` blocks include a metadata section with `total_tokens`, `tool_uses`, `duration_ms`, and `agentId`. This was not predicted in the original research — the "Observable vs Hidden" table initially listed token usage as hidden.
+**Context:** Analysis of PM agent JSONL data (April 14) revealed that subagent `tool_result` blocks include a metadata section with `total_tokens`, `tool_uses`, `duration_ms`, and `agentId`. This was not predicted in the original research -- the "Observable vs Hidden" table initially listed token usage as hidden.
 
 **Decision:** Expand #239 scope to capture the metadata block, enabling per-invocation cost and efficiency metrics.
 
 **Rationale:** The metadata provides enough data for meaningful agent analytics without needing Agent SDK internal traces: cost per invocation, efficiency (tokens per tool use), duration trends, and agent continuity tracking. This is low incremental effort (regex parse of a known format) with high analytical value.
 
-**Impact:** #239 scope grows slightly (metadata parsing), but delivers significantly richer agent metrics. No dependency changes — still v1.3 milestone alongside #238.
+**Impact:** #239 scope grows slightly (metadata parsing), but delivers significantly richer agent metrics. No dependency changes -- still v1.3 milestone alongside #238.
 
-## 2026-04-15: Subagent JSONL Trace Discovery — Roadmap Impact
+## 2026-04-15: Subagent JSONL Trace Discovery -- Roadmap Impact
 
 **Context:** Full subagent session traces discovered at `~/.claude/projects/<project>/<session-uuid>/subagents/agent-<id>.jsonl` (350 files, all with `isSidechain: true`). Previously believed to be hidden/inaccessible. Contains complete tool_use/tool_result sequences with `is_error` flags, per-step token usage, and internal reasoning.
 
@@ -90,7 +90,7 @@
 
 **Context:** The AgentFluent bootstrap strategy previously assumed data availability (hidden internal traces) was the trigger for a separate product. Full subagent traces eliminate this barrier.
 
-**Decision:** The trigger for AgentFluent as a separate product is now **audience divergence** — when CodeFluent needs to serve Agent SDK/production users with fundamentally different workflows (CI/CD integration, programmatic prompt versioning, batch analysis) that don't fit the interactive focus.
+**Decision:** The trigger for AgentFluent as a separate product is now **audience divergence** -- when CodeFluent needs to serve Agent SDK/production users with fundamentally different workflows (CI/CD integration, programmatic prompt versioning, batch analysis) that don't fit the interactive focus.
 
 **Rationale:** All features previously thought to require Agent SDK (prompt-to-behavior correlation, detailed error analysis, internal reasoning analysis) are available from existing Claude Code subagent data. The remaining Agent SDK-only needs (programmatic prompt version management, CI/CD hooks, custom instrumentation) serve a different user persona than CodeFluent's interactive Claude Code users.
 
@@ -120,18 +120,18 @@
 - Doc updates bringing READMEs and CLAUDE.md to v1.2.0 accuracy (#289)
 
 **What moves to v1.3:**
-- #248 — Normalize metrics by task type (2-3 days, both interfaces)
-- #247 — Learning trajectory + behavior acquisition curve (3-4 days, marquee feature)
-- #246 — Verification behaviors via tool sequence analysis (2-3 days, new module)
-- #101 — Behavior-token breakdown table (1-2 days, has data-pipeline gap)
-- #176 — Epic 4: Interaction Quality Metrics (parent; v1.2 shipped #245 + #218, remaining 4 stories deferred)
-- #174 — Epic 2: Task Classification (parent; v1.2 shipped #242, #243, #244, #219, #217; only #248 remains)
+- #248 -- Normalize metrics by task type (2-3 days, both interfaces)
+- #247 -- Learning trajectory + behavior acquisition curve (3-4 days, marquee feature)
+- #246 -- Verification behaviors via tool sequence analysis (2-3 days, new module)
+- #101 -- Behavior-token breakdown table (1-2 days, has data-pipeline gap)
+- #176 -- Epic 4: Interaction Quality Metrics (parent; v1.2 shipped #245 + #218, remaining 4 stories deferred)
+- #174 -- Epic 2: Task Classification (parent; v1.2 shipped #242, #243, #244, #219, #217; only #248 remains)
 
 **Rationale:**
-1. v1.2.0 already delivers substantial user value — scoring quality improvement (v2.1 prompt + Sonnet 4.6), new metrics (error recovery, command adoption), and infrastructure hardening (eval framework, security hooks)
+1. v1.2.0 already delivers substantial user value -- scoring quality improvement (v2.1 prompt + Sonnet 4.6), new metrics (error recovery, command adoption), and infrastructure hardening (eval framework, security hooks)
 2. The deferred stories total 9-12 days of implementation across both interfaces. Holding the release that long undermines cadence with no user-blocking reason.
 3. Option C was considered for #101 (smallest scope) but rejected: its data-pipeline gap (`joinSessionsWithScores` doesn't pass per-behavior flags) makes it larger than the 1-2 day estimate suggests, and implementing on release day is scope-creep.
-4. The deferred items cluster naturally with #251 (ccusage phase-out, also v1.3) — several touch the Usage tab analytics surface.
+4. The deferred items cluster naturally with #251 (ccusage phase-out, also v1.3) -- several touch the Usage tab analytics surface.
 5. No user-facing regression from deferring: all are net-new features, not fixes.
 
 **Epic milestone strategy:** Epics #176 and #174 follow their remaining stories to v1.3. The milestone field tracks "when will this close," not "when did planning start." Both epics had significant v1.2 work shipped (closed issues stay on v1.2 milestone).
@@ -145,8 +145,8 @@
 ### Decision 10: Epic 5 scoped to 5a only (radar + aggregation)
 
 **Options considered:**
-- A) Full Epic 5 (XL) — radar, agentic patterns, context efficiency, cost insights, CCA recommendations, parser enhancement
-- B) Epic 5a only (L) — radar chart + aggregation + CCA-aligned recommendations + parser enhancement (#160)
+- A) Full Epic 5 (XL) -- radar, agentic patterns, context efficiency, cost insights, CCA recommendations, parser enhancement
+- B) Epic 5a only (L) -- radar chart + aggregation + CCA-aligned recommendations + parser enhancement (#160)
 - C) Skip Epic 5 entirely, focus on completing deferred v1.2 stories + agent analytics
 
 **Decision:** Option B (5a only)
@@ -155,7 +155,7 @@
 
 **Impact:** v1.3 includes CCA radar chart, CCA-aligned recommendations, and parser enhancement (#160). Deeper Epic 5 features (token bloat detection, cost ROI, advanced agentic patterns) move to v2.0.
 
-### Decision 11: Epic 6 partial — only #115 and #116
+### Decision 11: Epic 6 partial -- only #115 and #116
 
 **Options considered:**
 - A) Full Epic 6 (all 5 stories: #112-#116)
@@ -166,7 +166,7 @@
 
 **Rationale:** #112 (multi-provider eval), #113 (human review loop), and #114 (cross-model agreement) all depend on having a second LLM provider integrated, which doesn't exist. Building infrastructure without a consumer is speculative engineering. #115 and #116 deliver standalone value: confidence calibration improves scoring transparency, user feedback enables golden set growth from real users.
 
-**Impact:** Three stories (#112, #113, #114) defer to v2.0. Epic 6 tracking issue (#178) stays open — it closes when all 5 stories ship. v1.3 ships two scoring quality improvements that are immediately useful.
+**Impact:** Three stories (#112, #113, #114) defer to v2.0. Epic 6 tracking issue (#178) stays open -- it closes when all 5 stories ship. v1.3 ships two scoring quality improvements that are immediately useful.
 
 ### Decision 12: Defer #209 (rules generation) and #298 (frontend hardening)
 
@@ -174,7 +174,7 @@
 
 **Decision:** #209 to v2.0; #298 to backlog.
 
-**Rationale:** #209 (rules generation) is scope-creep — it's an LLM-powered config generation feature unrelated to the v1.3 themes (CCA radar, interaction quality, agent analytics). It also depends on #199 (multi-level tabs) for UI placement. #298 (frontend rendering hardening) is good hygiene but the targeted fix already shipped in v1.2.1; the structural rewrite can happen incrementally as render functions are added or modified.
+**Rationale:** #209 (rules generation) is scope-creep -- it's an LLM-powered config generation feature unrelated to the v1.3 themes (CCA radar, interaction quality, agent analytics). It also depends on #199 (multi-level tabs) for UI placement. #298 (frontend rendering hardening) is good hygiene but the targeted fix already shipped in v1.2.1; the structural rewrite can happen incrementally as render functions are added or modified.
 
 **Impact:** v1.3 milestone shrinks by 2 issues. Both remain tracked for future work.
 
@@ -184,7 +184,7 @@
 
 **Decision:** Mark #256 as stretch. If #255 completes by Week 6, implement #256. Otherwise defer to v1.3.x or v2.0.
 
-**Rationale:** #256 reuses the error recovery algorithm from #245 — the implementation is modest. But its dependency (#255) is the risk. Declaring it stretch up front prevents pressure to rush #255 and lets the team ship without it if needed.
+**Rationale:** #256 reuses the error recovery algorithm from #245 -- the implementation is modest. But its dependency (#255) is the risk. Declaring it stretch up front prevents pressure to rush #255 and lets the team ship without it if needed.
 
 **Impact:** No issue changes. PRD documents the stretch designation. #256 is the first thing cut if velocity slips.
 
@@ -192,7 +192,7 @@
 
 **Context:** Epic 2 (Task Classification) had two phases. Phase A (heuristic) shipped v1.1. Phase B (LLM) shipped v1.2. The only remaining child issue is #248 (task-type normalization), which is labeled `epic:task-classification` + `epic:interaction-quality` and is functionally an Epic 4 completion story.
 
-**Decision:** Close #174. #248's primary value is normalizing interaction quality metrics — it belongs to Epic 4.
+**Decision:** Close #174. #248's primary value is normalizing interaction quality metrics -- it belongs to Epic 4.
 
 **Rationale:** Keeping #174 open for a single cross-labeled story creates tracking confusion. The epic's deliverables (heuristic classification, LLM classification, golden set expansion, eval check) are all complete.
 
@@ -211,3 +211,31 @@
 - **Q5 (#251 ccusage removal):** Full removal committed. JSONL token data is more accurate. Prior research exists. Marquee technical improvement for v1.3.
 
 **Impact:** PRD status changed from Draft to Approved. Epic 5a tracking issue #306 created. #177 scope narrowed via comment. #256 deferred from v1.3 stretch to v2.0/Epic 5b.
+
+## 2026-05-01: v1.3 Expanded -- E2E Automation
+
+### Decision 16: Add E2E smoke test automation (#312) to v1.3
+
+**Context:** Three doc-drift fixes in two releases (#294, plus two prior mismatches post-v1.2.0) exposed that the manual Playwright MCP checklist is fragile. Human explicitly approved v1.3 inclusion, citing it as "a constant pain point" that "would help streamline our workflow" and "may have caught a number of issues earlier."
+
+**Options considered:**
+- A) Add to v1.3 Phase 1 and cut something to compensate
+- B) Add to v1.3 Phase 1 and accept the overload (no cuts)
+- C) Mark as stretch goal (cut first if velocity slips)
+- D) Defer to v1.4 or backlog
+
+**Decision:** Option B (Add to Phase 1, accept overload, no cuts)
+
+**Rationale:**
+1. **Value-to-cost ratio is high.** M-sized work (1-2 days) that eliminates a per-PR manual testing bottleneck across the remaining 6+ weeks of v1.3 development. The time saved on manual smoke testing during Phases 2-4 likely exceeds the upfront investment.
+2. **Early placement maximizes ROI.** Phase 1 placement means automated regression catch is active before the riskiest UI changes land (#251 ccusage removal in Phase 2, CCA radar in Phase 3). This is the whole point -- catching regressions in the changes that follow.
+3. **No cuts needed.** The existing stretch goal (#101) and aggressive Phase 4 buffer already provide velocity slack. #312 at M-size fits within Phase 1 alongside the existing S-sized quick wins and M-sized #246. Phase 1 grows from ~1.5 weeks to ~2 weeks, which stays within the "Week 1-2" window.
+4. **Standalone story, no epic.** This is quality infrastructure, not scoring quality (#178/Epic 6). It has no epic parent and doesn't need one -- it's a self-contained CI improvement comparable to #293 (Dependabot drift) and #305 (release-please PAT) in the Bug Fixes & Hardening section.
+
+**Sequencing:** Phase 1, after #294 (doc fix that refreshes the checklist being automated) and alongside #246 (verification behaviors). No dependency on any other v1.3 work. No items on the critical path.
+
+**Scope-risk assessment:** v1.3 already carries 20+ issues with an "overload" risk flag. Adding one M-sized story to Phase 1 increases the total by ~5%. The overload risk mitigation remains unchanged: #101 is stretch, #256 is deferred, P2 items can slip to patches. The key difference from a generic scope add is that #312 *reduces* per-PR overhead for the remainder of the release, partially offsetting its own cost.
+
+**Coordination with #298:** Both touch webapp test infrastructure. #312 (E2E via Playwright) and #298 (frontend unit tests via JSDOM or Playwright) are complementary, not overlapping. #312 should land first -- it's smaller and unblocked. If #298 later chooses Playwright for its webapp test infra, the server fixture and dependency from #312 can be reused.
+
+**Impact:** New "Quality Infrastructure" section added to PRD scope tables. Phase 1 updated to include #312. Risk table updated to note the M-sized addition and its time-saving payback. Success criteria updated to include E2E automation.

--- a/.claude/specs/prd-v1.3-mastery.md
+++ b/.claude/specs/prd-v1.3-mastery.md
@@ -34,6 +34,7 @@ CodeFluent v1.2 shipped scoring prompt v2.1, error recovery detection, command a
 | User feedback mechanism | Flag button on behavior scores, local storage, export capability |
 | ccusage dependency removed | Usage data sourced entirely from JSONL files; ccusage no longer called |
 | Usage tab scoped | Pace cards and chart scoped to selected project |
+| E2E smoke tests automated | All 10 CLAUDE.md checklist items run as Playwright tests in CI |
 | Both interfaces | All features in VS Code extension AND webapp |
 
 ## Scope
@@ -72,6 +73,12 @@ CodeFluent v1.2 shipped scoring prompt v2.1, error recovery detection, command a
 |-------|-------|----------|------|-------|
 | #115 | Confidence calibration | P1 | M | Scoring prompt change, eval regression test |
 | #116 | User feedback signal | P1 | M | UI + local storage + export. Both interfaces. |
+
+### Quality Infrastructure
+
+| Issue | Title | Priority | Size | Notes |
+|-------|-------|----------|------|-------|
+| #312 | Automate E2E smoke checklist via Playwright | P1 | M | Replaces manual MCP workflow. Playwright Python tests for all 10 checklist items. CI job with path filtering. Lands early to catch regressions in Phase 2-3 UI work. |
 
 ### Bug Fixes & Hardening
 
@@ -131,6 +138,7 @@ Phase 1 -- Quick wins (Week 1-2)
   #294, #293, #305, #290          (doc + CI fixes, unblock future releases)
   #238                             (agent config scanning, S, unblocks #239)
   #246                             (verification behaviors, independent)
+  #312                             (E2E automation, M, no dependencies, high early value)
 
 Phase 2 -- Core analytics (Week 3-5)
   #251                             (ccusage removal, unblocks scoped usage)
@@ -161,6 +169,8 @@ Phase 4 -- Stretch (Week 7-8, if velocity allows)
 #255 ----------> (enriches #239, #240; #256 deferred to v2.0)
 ```
 
+**#312 (E2E automation) has no dependencies and is not on any critical path.** It provides value from the moment it lands by catching UI regressions in all subsequent PRs.
+
 ## Risks
 
 | Risk | Impact | Mitigation |
@@ -169,7 +179,7 @@ Phase 4 -- Stretch (Week 7-8, if velocity allows)
 | #255 (subagent parser) is complex | Delays agent analytics enrichment | #239 captures metadata from parent session tool_results without needing #255. Ship #239 first; #255 is P1 and enriches but doesn't block. |
 | Scoring prompt change for #115 | Eval regression risk | Run full eval suite. Keep v2.1 prompt as rollback. Confidence field is additive (doesn't change behavior scoring). |
 | #251 ccusage removal is marquee technical change | Data gaps, regression in usage metrics | Research already done — see PR #261 comparison table: ccusage's input-token overcounting and output-token undercounting (first-wins bug) are documented; JSONL message-ID dedup is the canonical approach per Anthropic docs. Build aggregation functions with unit tests pinning expected category-level totals. |
-| 20+ issues for solo maintainer | Overload | Aggressive stretch goal cuts. P2 items can slip to v1.3.x patches. #101 is stretch, #256 is deferred. |
+| 20+ issues for solo maintainer | Overload | Aggressive stretch goal cuts. P2 items can slip to v1.3.x patches. #101 is stretch, #256 is deferred. #312 (E2E) is M-sized but pays back immediately by reducing per-PR manual testing overhead — net time-saver over the release. Accepted as a deliberate human decision (2026-05-01). |
 
 ## Resolved Questions
 
@@ -182,3 +192,5 @@ Phase 4 -- Stretch (Week 7-8, if velocity allows)
 **Q4 -- Epic 5 split.** Split into Epic 5a (#306, v1.3: radar + aggregation + recommendations + parser #160) and Epic 5b (#177 narrowed, v2.0: deeper detection + cost insights + #256). No Epic 5c needed -- agent trace stories stay under Epic 4.
 
 **Q5 -- #251 ccusage scope.** Full removal committed. JSONL files contain native token data that is more accurate than ccusage. Prior research confirms data availability. This is a selling point for v1.3: "more accurate token usage tracking."
+
+**Q6 -- E2E automation added to v1.3 (2026-05-01).** Explicit human decision. #312 added to Phase 1 as Quality Infrastructure. No scope cuts required -- the M-sized cost is justified by three doc-drift fixes in two releases and the need for automated regression protection before v1.3's riskier UI changes (#251, CCA radar). #312 pays back its own cost by eliminating the per-PR manual smoke test overhead across Phases 2-4. See Decision 16 in `.claude/specs/decisions.md`.


### PR DESCRIPTION
## Summary

Captures the PM agent's scoping decision for #312 (E2E smoke checklist automation) and its impact on the v1.3 PRD.

## Why now

- A series of doc-drift fixes (#294 most recent) has exposed that the manual Playwright MCP checklist is fragile and goes stale silently between releases
- The user explicitly approved v1.3 inclusion citing it as a "constant pain point" that would have caught earlier issues
- PM agent recommended **Phase 1** placement so it lands before #251 ccusage removal and CCA radar (the riskiest UI changes in v1.3)
- New issue #312 was created with milestone v1.3 and labels `testing` / `webapp` / `frontend`

## PRD changes

- **Success Criteria:** new row "E2E smoke tests automated"
- **Scope:** new "Quality Infrastructure" section with #312 (P1, M)
- **Sequencing:** #312 added to Phase 1 (Week 1-2), explicit note that it has no dependencies and is not on any critical path
- **Risks:** overload row updated to flag #312 as a deliberate accept-with-justification (net time-saver across the rest of the release)
- **Resolved Questions:** new Q6 documenting the addition + decision date

## Decisions log

Decision 16 appended covering:
- Rationale (value-to-cost, three doc-drift fixes in two releases, user growth ambitions)
- Sequencing pick (Phase 1 for max early ROI)
- Scope-risk assessment (no cuts needed; the M-sized investment pays back across Phases 2-4)
- Coordination note with #298 (frontend rendering hardening, deferred to backlog) — both touch test infra; flagged for sequencing if #298 is ever revived

## Companion changes already live

- Issue #312 created (advisory milestone v1.3 set after PM completed)
- No issue closures or other GitHub mutations

## Test plan

- [x] No code changes — docs only
- [x] PRD diff is self-consistent (sequencing, scope, risk, resolved Q all reference each other)
- [x] Decision log entry follows the same format as Decisions 10-15
- [x] #312 exists, labeled, and milestoned

🤖 Generated with [Claude Code](https://claude.com/claude-code)