### PR TITLE
fix: make test/tsconfig.json self-contained for VS Code LSP (#290)

### DIFF
--- a/vscode-extension/test/tsconfig.json
+++ b/vscode-extension/test/tsconfig.json
@@ -1,12 +1,14 @@
 {
-  "extends": "../tsconfig.json",
   "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
     "rootDir": "..",
+    "lib": ["ES2020"],
     "noEmit": true,
-    "types": ["jest"]
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["jest", "node"]
   },
-  "include": [
-    "./**/*.ts",
-    "../src/**/*.ts"
-  ]
+  "include": ["./**/*.ts", "../src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

Replaces the \`extends\`-based \`vscode-extension/test/tsconfig.json\` with a self-contained config that inlines the parent's compiler options. Resolves the LSP \`Cannot find name 'jest'\` errors that appear in the editor for files under \`vscode-extension/test/\`.

## Why

The TypeScript language server doesn't reliably pick up \`test/tsconfig.json\` when it extends a parent config that excludes the same \`test/\` folder. CLI builds, \`npm test\`, and CI are all unaffected — this is editor-display-only — but the editor noise is constant.

This is **Option B** from #290 (the issue recommends trying it first; Option C is solution-style references with \`composite: true\`, more invasive). The smaller surface area of Option B is preferred when it works.

## Notable change: explicit \`types\` array

Without an explicit \`types\` list the parent config implicitly included **all** \`@types/*\` packages. Setting \`types: [\"jest\", \"node\"]\` restricts auto-included globals to those two:

- \`jest\` — gives the test files \`jest\`, \`expect\`, \`describe\`, \`it\`, etc.
- \`node\` — preserves Node globals (\`process\`, \`fs\`, etc.) in \`src/\` files transitively included for typecheck

\`@types/vscode\` is **unaffected** because it provides an ambient module declaration (\`declare module 'vscode'\`) that works via module resolution, not via the global \`types\` array. Verified by typecheck + full test suite.

## Test plan

- [x] \`npx tsc --noEmit -p test/tsconfig.json\` — exit 0
- [x] \`npm test\` — 962 pass, 24 suites
- [x] \`npm run compile\` — clean
- [x] CI green (npm test + npm run compile + vsce package on PR)
- [ ] **Manual:** Reviewer to open any file under \`vscode-extension/test/\` and confirm zero \`Cannot find name 'jest'\` errors after a TS server restart. (This is the only check we can't automate — it's the LSP behavior the issue is about.)

If the LSP errors persist after this lands and a TS server restart, fall through to Option C (solution-style references). Document outcome on the issue if reopened.

## Out of scope

- Test file imports or test code structure
- ESLint config (none exists)
- Webapp tsconfig (Python-based, no tsconfig)

🤖 Generated with [Claude Code](https://claude.com/claude-code)