### PR TITLE
feat: E2E test infrastructure + items 1-3 via Playwright (#312, Phase A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   changes:
     name: Detect changed paths

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,22 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      webapp: ${{ steps.filter.outputs.webapp }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            webapp:
+              - 'webapp/**'
+              - 'shared/**'
+              - '.github/workflows/ci.yml'
+
   test:
     name: Run Tests
     runs-on: ubuntu-latest
@@ -74,3 +90,26 @@ jobs:
       - name: Audit dependencies
         working-directory: webapp
         run: uv export --no-hashes > /tmp/requirements.txt && uvx pip-audit -r /tmp/requirements.txt
+
+  e2e:
+    name: Run E2E Tests
+    needs: changes
+    if: needs.changes.outputs.webapp == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        working-directory: webapp
+        run: uv sync --extra dev
+
+      - name: Install Playwright browser
+        working-directory: webapp
+        run: uv run playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        working-directory: webapp
+        run: uv run pytest tests/e2e/ -m e2e -v

--- a/webapp/pyproject.toml
+++ b/webapp/pyproject.toml
@@ -16,10 +16,13 @@ dev = [
     "pytest>=9.0.3",
     "httpx>=0.28.1",
     "pytest-asyncio>=0.24",
+    "playwright>=1.52.0",
+    "pytest-playwright>=0.6.2",
 ]
 
 [tool.pytest.ini_options]
-addopts = "-m 'not live'"
+addopts = "-m 'not live and not e2e'"
 markers = [
     "live: tests that hit the real Anthropic API (run with 'pytest -m live')",
+    "e2e: end-to-end tests via Playwright (run with 'pytest -m e2e' or 'pytest tests/e2e/')",
 ]

--- a/webapp/tests/e2e/README.md
+++ b/webapp/tests/e2e/README.md
@@ -1,0 +1,112 @@
+# Webapp E2E tests
+
+End-to-end Playwright tests that automate the manual smoke checklist from
+`CLAUDE.md`. Each test corresponds to one item in the 10-item checklist.
+
+**Status:** Phase A — infrastructure + 3 of 10 items implemented (#312).
+Remaining 7 items land in Phase B.
+
+| # | Checklist item | File | Status |
+|---|---|---|---|
+| 1 | Tab navigation (7 tabs) | `test_tab_navigation.py` | ✅ Phase A |
+| 2 | Settings bar visibility per tab | `test_settings_bar.py` | ✅ Phase A |
+| 3 | Project dropdown populates | `test_project_dropdown.py` | ✅ Phase A |
+| 4 | Fluency scoring | `test_fluency_scoring.py` | Phase B |
+| 5 | Conversations tab | `test_conversations.py` | Phase B |
+| 6 | Config tab | `test_config.py` | Phase B |
+| 7 | Prompt Optimizer | `test_optimizer.py` | Phase B |
+| 8 | Quick Wins | `test_quickwins.py` | Phase B |
+| 9 | Usage tab | `test_usage.py` | Phase B |
+| 10 | Health endpoint | `test_health.py` | Phase B |
+
+## Running locally
+
+From `webapp/`:
+
+```bash
+uv sync --extra dev
+uv run playwright install chromium    # one-time browser install
+uv run pytest tests/e2e/ -m e2e -v
+```
+
+E2E tests are excluded from the default `pytest tests/` run (via the
+`addopts = "-m 'not live and not e2e'"` config). Opt in explicitly with
+`-m e2e` or by passing the directory.
+
+## Server fixture
+
+`conftest.py` starts a real `uvicorn` subprocess pointed at a sandboxed
+temp data directory. One server boot per pytest session.
+
+- **Dynamic port** — picked via `socket.bind(0)` to avoid collisions with the
+  dev server or parallel CI jobs.
+- **Health polling** — polls `GET /health` with 200ms backoff until 200 or 503
+  (degraded-but-running). 15s timeout. On timeout or premature exit, the
+  fixture prints captured stderr from uvicorn so failures are diagnosable.
+- **`atexit` cleanup** — safety net in case of `KeyboardInterrupt` or pytest
+  crash. `proc.terminate()` is idempotent on a dead process.
+
+## Data strategy
+
+The webapp reads session JSONL from `CLAUDE_DATA_DIR` (env var, set in
+`webapp/main.py:_resolve_data_dir`). The server fixture sets this to a temp
+directory containing one mock session, mimicking
+`~/.claude/projects/<encoded-path>/<session>.jsonl`.
+
+The encoded project path is built from `$HOME` so server-side path validation
+(which requires the dir to be within `$HOME`) passes both locally and in CI.
+
+### Endpoint data coverage
+
+| Endpoint | Respects `CLAUDE_DATA_DIR`? | E2E strategy |
+|---|---|---|
+| `/api/conversations`, `/api/sessions` | Yes (`_resolve_data_dir`) | Seeded data |
+| `/api/scores`, `/api/run-scoring` | Yes | Seeded data + error-path on API call |
+| `/api/quickwins` | Yes | Seeded data + error-path on API call |
+| `/api/optimize` | N/A (no data lookup) | Error-path on API call |
+| `/api/conversation-analytics` | Yes | Seeded data |
+| `/api/usage` | **No — uses hardcoded `DATA_DIR`** | Empty-state assertion in Phase B |
+| `/api/config-maturity` | **No — scans real `~/.claude/`** | Empty-state assertion in Phase B |
+| `/health` | N/A | Direct HTTP assertion in Phase B |
+
+Phase B will treat empty-state rendering as itself a regression target — a
+graceful empty-state for `/api/config-maturity` and `/api/usage` is valuable
+coverage in its own right.
+
+## Mocking the Anthropic API
+
+**Strategy: error-path testing only (Phase B).** Tests that trigger API calls
+(items 4, 7, 8) run with a fake key (`sk-test-e2e-fake-key`) set by the
+server fixture. The Anthropic client constructor doesn't validate the key,
+but the API call fails. Tests assert the UI shows an error state (e.g., the
+results card displays a user-friendly message rather than crashing).
+
+Happy-path mocking (server-side stub or HTTP mock server) is deferred to a
+follow-up if value justifies the prod-code surface area. Architect concurred
+with this trade-off (#312 review, 2026-05-01).
+
+## Selector strategy
+
+**IDs first, never text.** The webapp HTML is ID-rich
+(`#tab-fluency`, `#run-scoring-btn`, `#data-path-group`), and IDs are
+stable across button-label changes. The doc-drift fixes that motivated #312
+(e.g., "Run Scoring" → "Run Analysis" caught only by PR #311) are exactly
+the kind of regression text-based selectors invite.
+
+`data-tab` attributes on tab buttons are an equally stable alternative used
+for tab-navigation tests.
+
+`data-testid` attributes are not currently in the HTML; introducing them
+would be coordinated with #298 (frontend rendering hardening) and is out
+of scope for #312.
+
+## CI
+
+The `e2e` job in `.github/workflows/ci.yml` runs only on PRs touching
+`webapp/` or `shared/` paths (filtered via `dorny/paths-filter`). The job
+is visible in the PR check list and shows as skipped on docs-only or
+extension-only PRs — required-status-checks gates still apply.
+
+Public repo: GitHub Actions Linux minutes are free, so the cost is
+wall-clock time on PR feedback, not money. Path filtering keeps that
+overhead off PRs that can't affect the webapp.

--- a/webapp/tests/e2e/_tabs.py
+++ b/webapp/tests/e2e/_tabs.py
@@ -1,0 +1,30 @@
+"""Shared tab metadata for E2E tests.
+
+Single source of truth for tab order and per-tab settings-bar visibility.
+Order matches `webapp/static/index.html:43-49` (the actual nav).
+
+Update this when the webapp's tab list changes; both `test_tab_navigation.py`
+and `test_settings_bar.py` derive from it.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class Tab(NamedTuple):
+    data_tab: str
+    panel_id: str
+    data_path_visible: bool
+    project_filter_visible: bool
+
+
+TABS: list[Tab] = [
+    Tab("fluency", "tab-fluency", True, True),
+    Tab("conversations", "tab-conversations", False, True),
+    Tab("recommendations", "tab-recommendations", False, False),
+    Tab("config", "tab-config", False, True),
+    Tab("optimizer", "tab-optimizer", False, True),
+    Tab("quickwins", "tab-quickwins", False, True),
+    Tab("usage", "tab-usage", False, True),
+]

--- a/webapp/tests/e2e/conftest.py
+++ b/webapp/tests/e2e/conftest.py
@@ -1,0 +1,200 @@
+"""Pytest fixtures for E2E tests.
+
+Server fixture starts a real uvicorn subprocess pointed at a sandboxed temp
+data directory (via CLAUDE_DATA_DIR env var) and yields a base URL. Tests
+interact via Playwright against this server.
+
+Design notes:
+- Session-scope server (one boot per pytest session — fast)
+- Dynamic port (avoids collisions with dev server / other CI jobs)
+- /health polling with backoff (avoids race on startup)
+- Stderr captured to a temp file; printed on test failure for debuggability
+- atexit cleanup (safety net for KeyboardInterrupt or pytest crash)
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from collections import namedtuple
+from pathlib import Path
+
+import pytest
+import requests
+
+E2E_API_KEY = "sk-test-e2e-fake-key"  # noqa: S105 — fake key, never used for a real call
+HEALTH_TIMEOUT_SECONDS = 15
+HEALTH_POLL_INTERVAL = 0.2
+
+ServerInfo = namedtuple("ServerInfo", ["base_url", "data_dir", "project_name"])
+
+
+def _pick_free_port() -> int:
+    """Bind to port 0 to let the kernel assign a free port, then close and return it.
+
+    Race-prone in theory, but fine in practice for local/CI use — the OS will not
+    immediately reuse the port for another listener within the brief window before
+    uvicorn binds it.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _seed_data_dir(root: Path) -> str:
+    """Populate a temp dir with mock JSONL session data and return the project name.
+
+    Mirrors the structure of `~/.claude/projects/` so the parser sees a real-looking
+    project. The encoded project name uses `$HOME` so server-side path validation
+    (which requires data dir to be within $HOME) passes.
+    """
+    home = str(Path.home())
+    project_encoded = home.replace("/", "-") + "-e2e-test-project"
+    project_short = "e2e-test-project"
+    project = root / project_encoded
+    project.mkdir(parents=True, exist_ok=True)
+
+    session_id = "e2e0aaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    mock_cwd = f"{home}/e2e-test-project"
+
+    lines = [
+        {
+            "type": "user",
+            "sessionId": session_id,
+            "version": "2.1.44",
+            "gitBranch": "main",
+            "cwd": mock_cwd,
+            "message": {"role": "user", "content": "E2E smoke test prompt"},
+            "uuid": "e2e-msg-1",
+            "timestamp": "2026-04-01T10:00:00.000Z",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "model": "claude-sonnet-4-6",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "E2E smoke test response."}],
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
+            },
+            "timestamp": "2026-04-01T10:00:02.000Z",
+        },
+    ]
+
+    jsonl_file = project / f"{session_id}.jsonl"
+    with jsonl_file.open("w") as f:
+        for line in lines:
+            f.write(json.dumps(line) + "\n")
+
+    return project_short
+
+
+@pytest.fixture(scope="session")
+def e2e_server(tmp_path_factory) -> ServerInfo:
+    """Start uvicorn pointed at a seeded temp data dir; yield ServerInfo.
+
+    Session-scoped so all e2e tests share one server boot. Tests must not
+    mutate server-side state in ways that affect later tests.
+    """
+    data_dir = tmp_path_factory.mktemp("e2e-data")
+    project_name = _seed_data_dir(data_dir)
+    port = _pick_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    stderr_log = tmp_path_factory.mktemp("e2e-logs") / "uvicorn.stderr"
+    stderr_fp = stderr_log.open("wb")
+
+    env = {
+        **os.environ,
+        "CLAUDE_DATA_DIR": str(data_dir),
+        "ANTHROPIC_API_KEY": E2E_API_KEY,
+    }
+
+    webapp_dir = Path(__file__).resolve().parent.parent.parent  # tests/e2e -> tests -> webapp
+    proc = subprocess.Popen(  # noqa: S603 — args list, not shell
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "main:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--log-level",
+            "warning",
+        ],
+        cwd=str(webapp_dir),
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=stderr_fp,
+    )
+
+    # atexit safety net — fires on KeyboardInterrupt, sys.exit, or normal pytest
+    # teardown. Idempotent: terminate() on an already-dead process is a no-op.
+    def _cleanup():
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        stderr_fp.close()
+
+    atexit.register(_cleanup)
+
+    # Poll /health with backoff
+    deadline = time.monotonic() + HEALTH_TIMEOUT_SECONDS
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            stderr_fp.flush()
+            stderr = stderr_log.read_text(errors="replace")
+            pytest.fail(
+                f"uvicorn exited before /health was ready (returncode={proc.returncode}).\n"
+                f"stderr:\n{stderr}"
+            )
+        try:
+            r = requests.get(f"{base_url}/health", timeout=1)
+            if r.status_code in (200, 503):
+                # 503 is "degraded" (e.g., missing API key) — server is up regardless
+                break
+        except requests.RequestException as e:
+            last_error = e
+        time.sleep(HEALTH_POLL_INTERVAL)
+    else:
+        stderr_fp.flush()
+        stderr = stderr_log.read_text(errors="replace")
+        _cleanup()
+        pytest.fail(
+            f"uvicorn /health did not become ready within {HEALTH_TIMEOUT_SECONDS}s "
+            f"(last error: {last_error}).\nstderr:\n{stderr}"
+        )
+
+    yield ServerInfo(base_url=base_url, data_dir=data_dir, project_name=project_name)
+
+    _cleanup()
+
+
+@pytest.fixture(scope="session")
+def base_url(e2e_server) -> str:
+    """Override pytest-base-url's base_url so `page.goto('/')` hits our server."""
+    return e2e_server.base_url
+
+
+@pytest.fixture(scope="session")
+def browser_context_args(browser_context_args):
+    """Disable PR-flaky animations and use a stable viewport."""
+    return {
+        **browser_context_args,
+        "viewport": {"width": 1280, "height": 800},
+    }

--- a/webapp/tests/e2e/conftest.py
+++ b/webapp/tests/e2e/conftest.py
@@ -9,12 +9,11 @@ Design notes:
 - Dynamic port (avoids collisions with dev server / other CI jobs)
 - /health polling with backoff (avoids race on startup)
 - Stderr captured to a temp file; printed on test failure for debuggability
-- atexit cleanup (safety net for KeyboardInterrupt or pytest crash)
+- try/finally ensures cleanup even if the test session crashes mid-run
 """
 
 from __future__ import annotations
 
-import atexit
 import json
 import os
 import socket
@@ -30,6 +29,7 @@ import requests
 E2E_API_KEY = "sk-test-e2e-fake-key"  # noqa: S105 — fake key, never used for a real call
 HEALTH_TIMEOUT_SECONDS = 15
 HEALTH_POLL_INTERVAL = 0.2
+TERMINATE_TIMEOUT_SECONDS = 5
 
 ServerInfo = namedtuple("ServerInfo", ["base_url", "data_dir", "project_name"])
 
@@ -51,7 +51,8 @@ def _seed_data_dir(root: Path) -> str:
 
     Mirrors the structure of `~/.claude/projects/` so the parser sees a real-looking
     project. The encoded project name uses `$HOME` so server-side path validation
-    (which requires data dir to be within $HOME) passes.
+    (which requires data dir to be within $HOME) passes. Encoding scheme matches
+    `_decode_project_path` in webapp/main.py.
     """
     home = str(Path.home())
     project_encoded = home.replace("/", "-") + "-e2e-test-project"
@@ -139,50 +140,43 @@ def e2e_server(tmp_path_factory) -> ServerInfo:
         stderr=stderr_fp,
     )
 
-    # atexit safety net — fires on KeyboardInterrupt, sys.exit, or normal pytest
-    # teardown. Idempotent: terminate() on an already-dead process is a no-op.
-    def _cleanup():
-        if proc.poll() is None:
-            proc.terminate()
+    try:
+        # Poll /health with backoff
+        deadline = time.monotonic() + HEALTH_TIMEOUT_SECONDS
+        last_error: Exception | None = None
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                stderr_fp.flush()
+                stderr = stderr_log.read_text(errors="replace")
+                pytest.fail(
+                    f"uvicorn exited before /health was ready (returncode={proc.returncode}).\n"
+                    f"stderr:\n{stderr}"
+                )
             try:
-                proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-        stderr_fp.close()
-
-    atexit.register(_cleanup)
-
-    # Poll /health with backoff
-    deadline = time.monotonic() + HEALTH_TIMEOUT_SECONDS
-    last_error: Exception | None = None
-    while time.monotonic() < deadline:
-        if proc.poll() is not None:
+                r = requests.get(f"{base_url}/health", timeout=1)
+                if r.status_code in (200, 503):
+                    # 503 is "degraded" (e.g., missing API key) — server is up regardless
+                    break
+            except requests.RequestException as e:
+                last_error = e
+            time.sleep(HEALTH_POLL_INTERVAL)
+        else:
             stderr_fp.flush()
             stderr = stderr_log.read_text(errors="replace")
             pytest.fail(
-                f"uvicorn exited before /health was ready (returncode={proc.returncode}).\n"
-                f"stderr:\n{stderr}"
+                f"uvicorn /health did not become ready within {HEALTH_TIMEOUT_SECONDS}s "
+                f"(last error: {last_error}).\nstderr:\n{stderr}"
             )
-        try:
-            r = requests.get(f"{base_url}/health", timeout=1)
-            if r.status_code in (200, 503):
-                # 503 is "degraded" (e.g., missing API key) — server is up regardless
-                break
-        except requests.RequestException as e:
-            last_error = e
-        time.sleep(HEALTH_POLL_INTERVAL)
-    else:
-        stderr_fp.flush()
-        stderr = stderr_log.read_text(errors="replace")
-        _cleanup()
-        pytest.fail(
-            f"uvicorn /health did not become ready within {HEALTH_TIMEOUT_SECONDS}s "
-            f"(last error: {last_error}).\nstderr:\n{stderr}"
-        )
 
-    yield ServerInfo(base_url=base_url, data_dir=data_dir, project_name=project_name)
-
-    _cleanup()
+        yield ServerInfo(base_url=base_url, data_dir=data_dir, project_name=project_name)
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=TERMINATE_TIMEOUT_SECONDS)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        stderr_fp.close()
 
 
 @pytest.fixture(scope="session")

--- a/webapp/tests/e2e/test_project_dropdown.py
+++ b/webapp/tests/e2e/test_project_dropdown.py
@@ -41,7 +41,5 @@ def test_project_dropdown_has_more_than_placeholder(page: Page):
     silently and leaving only the placeholder.
     """
     page.goto("/")
-    options = page.locator("#project-filter option")
-    # Wait for at least 2 options (placeholder + seeded project)
-    expect(options).not_to_have_count(1)
-    expect(options).not_to_have_count(0)
+    # Wait for the second option to attach (placeholder is index 0, real project is index 1+).
+    expect(page.locator("#project-filter option").nth(1)).to_be_attached()

--- a/webapp/tests/e2e/test_project_dropdown.py
+++ b/webapp/tests/e2e/test_project_dropdown.py
@@ -1,0 +1,47 @@
+"""E2E item 3: Project dropdown populates from session data.
+
+The webapp reads session data from `CLAUDE_DATA_DIR` (server-side env var) on
+load. With our seeded test data, the project dropdown should populate with at
+least the seeded project beyond the default "All projects" placeholder.
+
+This test verifies the round-trip: server reads JSONL, frontend fetches
+projects, dropdown renders options. Catches breakage in any link of that chain.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+
+
+@pytest.mark.e2e
+def test_project_dropdown_populates_from_seeded_data(page: Page, e2e_server):
+    """The seeded project should appear as an option after the page loads."""
+    page.goto("/")
+
+    # Default tab is Fluency Score; project dropdown is shown there per the
+    # settings-bar spec. The dropdown starts with one placeholder option ("All
+    # projects") and gains entries as session data loads from the backend.
+    project_filter = page.locator("#project-filter")
+    expect(project_filter).to_be_visible()
+
+    # Wait for the seeded project to appear. Playwright auto-waits up to the
+    # default timeout for the option to materialize.
+    seeded_option = project_filter.locator(
+        f'option:has-text("{e2e_server.project_name}")'
+    )
+    expect(seeded_option).to_have_count(1)
+
+
+@pytest.mark.e2e
+def test_project_dropdown_has_more_than_placeholder(page: Page):
+    """Dropdown has >1 option once data loads (placeholder + at least one project).
+
+    Smoke check independent of project name — guards against the load failing
+    silently and leaving only the placeholder.
+    """
+    page.goto("/")
+    options = page.locator("#project-filter option")
+    # Wait for at least 2 options (placeholder + seeded project)
+    expect(options).not_to_have_count(1)
+    expect(options).not_to_have_count(0)

--- a/webapp/tests/e2e/test_settings_bar.py
+++ b/webapp/tests/e2e/test_settings_bar.py
@@ -1,0 +1,55 @@
+"""E2E item 2: Settings bar visibility per tab.
+
+Per CLAUDE.md E2E checklist item 2:
+- `#data-path-group` (session data path input) visible ONLY on Fluency Score
+- `#project-filter-group` (project dropdown) visible on every tab EXCEPT Recommendations
+- Settings bar hidden entirely on Recommendations
+
+Drives the test from the spec table to keep the contract explicit and easy to
+update when tabs or visibility rules change.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+
+# Per-tab expected visibility: (data_tab, data_path_visible, project_filter_visible)
+VISIBILITY_SPEC = [
+    ("fluency", True, True),
+    ("conversations", False, True),
+    ("recommendations", False, False),
+    ("config", False, True),
+    ("optimizer", False, True),
+    ("quickwins", False, True),
+    ("usage", False, True),
+]
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    ("data_tab", "data_path_visible", "project_filter_visible"),
+    VISIBILITY_SPEC,
+    ids=[s[0] for s in VISIBILITY_SPEC],
+)
+def test_settings_bar_visibility_per_tab(
+    page: Page,
+    data_tab: str,
+    data_path_visible: bool,
+    project_filter_visible: bool,
+):
+    page.goto("/")
+    page.locator(f'button.tab[data-tab="{data_tab}"]').click()
+
+    data_path = page.locator("#data-path-group")
+    project_filter = page.locator("#project-filter-group")
+
+    if data_path_visible:
+        expect(data_path).to_be_visible()
+    else:
+        expect(data_path).to_be_hidden()
+
+    if project_filter_visible:
+        expect(project_filter).to_be_visible()
+    else:
+        expect(project_filter).to_be_hidden()

--- a/webapp/tests/e2e/test_settings_bar.py
+++ b/webapp/tests/e2e/test_settings_bar.py
@@ -5,8 +5,7 @@ Per CLAUDE.md E2E checklist item 2:
 - `#project-filter-group` (project dropdown) visible on every tab EXCEPT Recommendations
 - Settings bar hidden entirely on Recommendations
 
-Drives the test from the spec table to keep the contract explicit and easy to
-update when tabs or visibility rules change.
+Visibility rules live in `_tabs.TABS`; this test consumes them.
 """
 
 from __future__ import annotations
@@ -14,42 +13,24 @@ from __future__ import annotations
 import pytest
 from playwright.sync_api import Page, expect
 
-# Per-tab expected visibility: (data_tab, data_path_visible, project_filter_visible)
-VISIBILITY_SPEC = [
-    ("fluency", True, True),
-    ("conversations", False, True),
-    ("recommendations", False, False),
-    ("config", False, True),
-    ("optimizer", False, True),
-    ("quickwins", False, True),
-    ("usage", False, True),
-]
+from ._tabs import TABS
 
 
 @pytest.mark.e2e
-@pytest.mark.parametrize(
-    ("data_tab", "data_path_visible", "project_filter_visible"),
-    VISIBILITY_SPEC,
-    ids=[s[0] for s in VISIBILITY_SPEC],
-)
-def test_settings_bar_visibility_per_tab(
-    page: Page,
-    data_tab: str,
-    data_path_visible: bool,
-    project_filter_visible: bool,
-):
+@pytest.mark.parametrize("tab", TABS, ids=[t.data_tab for t in TABS])
+def test_settings_bar_visibility_per_tab(page: Page, tab):
     page.goto("/")
-    page.locator(f'button.tab[data-tab="{data_tab}"]').click()
+    page.locator(f'button.tab[data-tab="{tab.data_tab}"]').click()
 
     data_path = page.locator("#data-path-group")
     project_filter = page.locator("#project-filter-group")
 
-    if data_path_visible:
+    if tab.data_path_visible:
         expect(data_path).to_be_visible()
     else:
         expect(data_path).to_be_hidden()
 
-    if project_filter_visible:
+    if tab.project_filter_visible:
         expect(project_filter).to_be_visible()
     else:
         expect(project_filter).to_be_hidden()

--- a/webapp/tests/e2e/test_tab_navigation.py
+++ b/webapp/tests/e2e/test_tab_navigation.py
@@ -11,31 +11,22 @@ from __future__ import annotations
 import pytest
 from playwright.sync_api import Page, expect
 
-# (data-tab attribute on button, panel id) — order matches webapp/static/index.html nav
-TAB_ORDER = [
-    ("fluency", "tab-fluency"),
-    ("conversations", "tab-conversations"),
-    ("recommendations", "tab-recommendations"),
-    ("config", "tab-config"),
-    ("optimizer", "tab-optimizer"),
-    ("quickwins", "tab-quickwins"),
-    ("usage", "tab-usage"),
-]
+from ._tabs import TABS
 
 
 @pytest.mark.e2e
 def test_all_seven_tabs_present(page: Page):
     """Every tab from the spec is present in the nav."""
     page.goto("/")
-    for data_tab, _panel_id in TAB_ORDER:
-        expect(page.locator(f'button.tab[data-tab="{data_tab}"]')).to_be_visible()
+    for tab in TABS:
+        expect(page.locator(f'button.tab[data-tab="{tab.data_tab}"]')).to_be_visible()
 
 
 @pytest.mark.e2e
-def test_tab_count_is_seven(page: Page):
+def test_tab_count_matches_spec(page: Page):
     """Guards against drift: catches a missing or accidentally-added tab."""
     page.goto("/")
-    expect(page.locator("button.tab")).to_have_count(len(TAB_ORDER))
+    expect(page.locator("button.tab")).to_have_count(len(TABS))
 
 
 @pytest.mark.e2e
@@ -48,15 +39,12 @@ def test_clicking_each_tab_activates_only_its_panel(page: Page):
     """
     page.goto("/")
 
-    for data_tab, panel_id in TAB_ORDER:
-        page.locator(f'button.tab[data-tab="{data_tab}"]').click()
+    for tab in TABS:
+        page.locator(f'button.tab[data-tab="{tab.data_tab}"]').click()
 
-        # Active panel for this tab is visible; all other panels are not.
-        # `tab-panel.active` is the class combo the app uses to show a panel
-        # (panels without `.active` are hidden via CSS, so are non-visible).
-        expect(page.locator(f"#{panel_id}.active")).to_be_visible()
+        expect(page.locator(f"#{tab.panel_id}.active")).to_be_visible()
 
-        for _other_tab, other_panel_id in TAB_ORDER:
-            if other_panel_id == panel_id:
+        for other in TABS:
+            if other.panel_id == tab.panel_id:
                 continue
-            expect(page.locator(f"#{other_panel_id}.active")).to_have_count(0)
+            expect(page.locator(f"#{other.panel_id}.active")).to_have_count(0)

--- a/webapp/tests/e2e/test_tab_navigation.py
+++ b/webapp/tests/e2e/test_tab_navigation.py
@@ -1,0 +1,62 @@
+"""E2E item 1: Tab navigation — all 7 tabs switch correctly, correct panel is visible.
+
+Asserts that clicking each `button.tab` activates the matching `#tab-{name}` panel
+and deactivates all others. Uses element IDs and `data-tab` attributes as primary
+selectors (stable; immune to button-label drift like the "Run Scoring" -> "Run Analysis"
+rename caught by #311).
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+
+# (data-tab attribute on button, panel id) — order matches webapp/static/index.html nav
+TAB_ORDER = [
+    ("fluency", "tab-fluency"),
+    ("conversations", "tab-conversations"),
+    ("recommendations", "tab-recommendations"),
+    ("config", "tab-config"),
+    ("optimizer", "tab-optimizer"),
+    ("quickwins", "tab-quickwins"),
+    ("usage", "tab-usage"),
+]
+
+
+@pytest.mark.e2e
+def test_all_seven_tabs_present(page: Page):
+    """Every tab from the spec is present in the nav."""
+    page.goto("/")
+    for data_tab, _panel_id in TAB_ORDER:
+        expect(page.locator(f'button.tab[data-tab="{data_tab}"]')).to_be_visible()
+
+
+@pytest.mark.e2e
+def test_tab_count_is_seven(page: Page):
+    """Guards against drift: catches a missing or accidentally-added tab."""
+    page.goto("/")
+    expect(page.locator("button.tab")).to_have_count(len(TAB_ORDER))
+
+
+@pytest.mark.e2e
+def test_clicking_each_tab_activates_only_its_panel(page: Page):
+    """For each tab, clicking it makes the matching panel active and others inactive.
+
+    Uses compound selectors (`#tab-foo.active`) rather than checking the class
+    attribute string — this is what the user actually sees and is robust to
+    classes being reordered or extra classes being added.
+    """
+    page.goto("/")
+
+    for data_tab, panel_id in TAB_ORDER:
+        page.locator(f'button.tab[data-tab="{data_tab}"]').click()
+
+        # Active panel for this tab is visible; all other panels are not.
+        # `tab-panel.active` is the class combo the app uses to show a panel
+        # (panels without `.active` are hidden via CSS, so are non-visible).
+        expect(page.locator(f"#{panel_id}.active")).to_be_visible()
+
+        for _other_tab, other_panel_id in TAB_ORDER:
+            if other_panel_id == panel_id:
+                continue
+            expect(page.locator(f"#{other_panel_id}.active")).to_have_count(0)

--- a/webapp/uv.lock
+++ b/webapp/uv.lock
@@ -62,6 +62,79 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -87,8 +160,10 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "playwright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-playwright" },
 ]
 
 [package.metadata]
@@ -96,8 +171,10 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.94.0" },
     { name = "fastapi", specifier = ">=0.135.3" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.1" },
+    { name = "playwright", marker = "extra == 'dev'", specifier = ">=1.52.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
+    { name = "pytest-playwright", marker = "extra == 'dev'", specifier = ">=0.6.2" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "uvicorn", specifier = ">=0.41.0" },
 ]
@@ -144,6 +221,53 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98", size = 117734, upload-time = "2026-04-01T16:23:59.328Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cb/baa584cb00532126ffe12d9787db0a60c5a4f55c27bfe2666df5d4c30a32/greenlet-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:83ed9f27f1680b50e89f40f6df348a290ea234b249a4003d366663a12eab94f2", size = 235615, upload-time = "2026-04-27T12:21:38.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
+    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
 ]
 
 [[package]]
@@ -279,6 +403,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.59.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/48/abab23f40643b4de8f2665816f0a1bf0994eeecda39d6d62f0f292b2ad01/playwright-1.59.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:bfc6940100b57423175c819ce2422ec5880d55fa2769987f62ab7a1f5fe6783e", size = 43156922, upload-time = "2026-04-29T08:11:08.921Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/5e4d98b2ce3641b4343623c6450ff33b9de1c979d12a957505e392338b07/playwright-1.59.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:af068143a0c045ec11608b67d6c42e58db7e9cf65a742dd21fddedc1a9802c47", size = 41947177, upload-time = "2026-04-29T08:11:12.867Z" },
+    { url = "https://files.pythonhosted.org/packages/80/91/fd219aa78ca03d37e93aaedaed4e224131e3090a9264f9bb773c8271d67e/playwright-1.59.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:4a4a2d4842b0e4120de3fa48636e4b69085a05b81d8a35ad4353f530ade72ed6", size = 43156922, upload-time = "2026-04-29T08:11:16.595Z" },
+    { url = "https://files.pythonhosted.org/packages/73/0c/1e513d37c5be07d12829ebce93dbfe7baee230084cb66966c423432799c4/playwright-1.59.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c5792aad9e22b91a09264b9edbc18553cf05ea5a39404d65dc19a012c6b2e51d", size = 47151793, upload-time = "2026-04-29T08:11:19.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2d/15f72288cb65d690134e18fefb9483cc4976f7579b580648c45e494481a7/playwright-1.59.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c881a19377d2b900af855fb525b5f22a27bf3cfbecba6d1edb36766d56cb100", size = 46877615, upload-time = "2026-04-29T08:11:23.863Z" },
+    { url = "https://files.pythonhosted.org/packages/72/a1/717ac5bc99f387c0f60def91271ea4262125c0815d764a5d1776a272275c/playwright-1.59.0-py3-none-win32.whl", hash = "sha256:6989c476be2b9cd3e24a18cc9dcf202e266fb3d91e3e5395cd668c54ea54b119", size = 37713698, upload-time = "2026-04-29T08:11:27.251Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a5/4e630ee05d8b46b840f943268e86d6063703e8dadb2d3eb405c7b9b2e48c/playwright-1.59.0-py3-none-win_amd64.whl", hash = "sha256:d5a5cc064b82ca92996080025710844e417f44df8fda9001102c28f44174171c", size = 37713704, upload-time = "2026-04-29T08:11:30.41Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0c/3ece41761ba13c8321009aefcaec7a016eb42799c42eef5e03ace7f2de5b/playwright-1.59.0-py3-none-win_arm64.whl", hash = "sha256:93581ad515728cadc8af39b288a5633ba6d36e7d72048e79d890ce01ea2156f9", size = 33956745, upload-time = "2026-04-29T08:11:34.738Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -374,6 +517,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -412,12 +567,67 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-base-url"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/1a/b64ac368de6b993135cb70ca4e5d958a5c268094a3a2a4cac6f0021b6c4f/pytest_base_url-2.1.0.tar.gz", hash = "sha256:02748589a54f9e63fcbe62301d6b0496da0d10231b753e950c63e03aee745d45", size = 6702, upload-time = "2024-01-31T22:43:00.81Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl", hash = "sha256:3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6", size = 5302, upload-time = "2024-01-31T22:42:58.897Z" },
+]
+
+[[package]]
+name = "pytest-playwright"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "playwright" },
+    { name = "pytest" },
+    { name = "pytest-base-url" },
+    { name = "python-slugify" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/6b/913e36aa421b35689ec95ed953ff7e8df3f2ee1c7b8ab2a3f1fd39d95faf/pytest_playwright-0.7.2.tar.gz", hash = "sha256:247b61123b28c7e8febb993a187a07e54f14a9aa04edc166f7a976d88f04c770", size = 16928, upload-time = "2025-11-24T03:43:22.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/61/4d333d8354ea2bea2c2f01bad0a4aa3c1262de20e1241f78e73360e9b620/pytest_playwright-0.7.2-py3-none-any.whl", hash = "sha256:8084e015b2b3ecff483c2160f1c8219b38b66c0d4578b23c0f700d1b0240ea38", size = 16881, upload-time = "2025-11-24T03:43:24.423Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]
@@ -443,6 +653,15 @@ wheels = [
 ]
 
 [[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -461,6 +680,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Phase A of #312. Lands the foundation for automated E2E smoke testing and converts the first 3 of 10 CLAUDE.md checklist items into Playwright tests. Phase B will add the remaining 7 tests plus the CLAUDE.md primary-verification update.

## What's in Phase A

### Tests (12 cases across 3 items)

| # | Checklist item | File | Cases |
|---|---|---|---|
| 1 | Tab navigation (all 7 tabs) | `test_tab_navigation.py` | 3 |
| 2 | Settings bar visibility per tab | `test_settings_bar.py` | 7 (parametrized) |
| 3 | Project dropdown populates | `test_project_dropdown.py` | 2 |

Selectors are ID-first (`#tab-fluency`, `#data-path-group`) and `data-tab` attribute-based, never text. This deliberately protects against the kind of button-label drift PR #311 had to catch (`Run Scoring` → `Run Analysis`).

### Infrastructure

- **`webapp/pyproject.toml`** — adds `playwright>=1.52.0` and `pytest-playwright>=0.6.2` to dev deps; new `e2e` pytest marker is excluded from default runs (`addopts = "-m 'not live and not e2e'"`), so the existing `test-webapp` CI job is unaffected.
- **`webapp/tests/e2e/conftest.py`** — session-scope server fixture:
  - Dynamic port via `socket.bind(0)` (no collision with dev server / parallel CI jobs)
  - `/health` polling with 200ms backoff, 15s timeout, captures stderr to a temp file and prints it on startup failure for diagnosability
  - `atexit.register` cleanup safety net (idempotent `terminate()` on dead processes)
  - Seeds a temp data dir with mock JSONL and starts uvicorn with `CLAUDE_DATA_DIR=<temp>` so the server reads from the sandbox
- **`.github/workflows/ci.yml`** — new `changes` setup job uses `dorny/paths-filter@v3` to detect `webapp/`, `shared/`, or `ci.yml` changes; new `e2e` job is conditional on its output. The job appears in the PR checks list and shows as skipped on docs-only / extension-only PRs (preserves required-status-checks gating).
- **`webapp/tests/e2e/README.md`** — documents mocking strategy, data seeding, per-endpoint coverage map (foundation for Phase B), and selector strategy.

## Architect review baked in

The architect comment on #312 (2026-05-01) green-lit all 5 design decisions and flagged 3 implementation details — all are in this PR:
- ✅ Server startup race protection (poll + capture stderr)
- ✅ Port collision avoidance (dynamic port)
- ✅ Subprocess cleanup safety net (`atexit.register`)

Forward-compat verified by architect against #251 (ccusage removal), #298 (frontend hardening), CCA radar, and #238/#239 — no conflicts.

## Verified locally

```
uv run pytest tests/             — 796 passed, 15 deselected (3 live + 12 e2e)  [5.7s]
uv run pytest tests/e2e/ -m e2e  — 12 passed                                    [6.5s]
```

The marker config correctly routes: `e2e` tests deselected from default runs, opt-in via `-m e2e` or by passing `tests/e2e/`.

## What's NOT in Phase A

Per the architect-approved phasing plan:

- **Items 4-10** — Phase B (next PR)
- **`CLAUDE.md` E2E section update** to point at `webapp/tests/e2e/` as primary verification — Phase B (we want the suite complete before redirecting users away from the manual checklist)
- **Happy-path Anthropic API mocking** — deferred per architect; Phase B asserts error-path UI behavior with a fake API key
- **`data-testid` attributes** — out of scope; coordinated with #298 if/when that's revived

## Test plan

- [x] `uv run pytest tests/` — 796 passed, 15 deselected
- [x] `uv run pytest tests/e2e/ -m e2e -v` — 12 passed in 6.5s
- [x] Lockfile regenerated; `uv lock --check` clean
- [x] No production code touched (the `_resolve_data_dir` env var path was already there per architect verification)
- [x] CI green: `test`, `test-webapp`, and `e2e` jobs all pass on this PR
- [ ] CI behavior: `e2e` job shows as skipped on a follow-up docs-only commit (will verify post-merge with the next docs PR if anyone runs into it)

## Out of scope

- Adding `pytest-timeout` (Playwright's built-in 30s per-action auto-wait + 15s health-poll timeout cover the failure modes that matter)
- Browser matrix beyond Chromium (locked in by #312 already)
- Visual regression / screenshot diffing (excluded from #312)

## Refs

- Closes part of #312 (Phase A); Phase B continues in a follow-up PR
- Architect review: https://github.com/frederick-douglas-pearce/codefluent/issues/312#issuecomment-4358483026
- v1.3 PRD: `.claude/specs/prd-v1.3-mastery.md` Phase 1 sequencing
- Motivation: PRs #294, #311 (doc-drift fixes that exposed manual checklist fragility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)