### PR TITLE
ci: cache Playwright browsers and enable uv cache (#316)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,8 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('webapp/uv.lock') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
 
       - name: Install Playwright system dependencies
         working-directory: webapp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: webapp/uv.lock
 
       - name: Verify uv.lock
         working-directory: webapp
@@ -105,14 +108,27 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: webapp/uv.lock
 
       - name: Install dependencies
         working-directory: webapp
         run: uv sync --extra dev
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('webapp/uv.lock') }}
+
+      - name: Install Playwright system dependencies
+        working-directory: webapp
+        run: uv run playwright install-deps chromium
+
       - name: Install Playwright browser
         working-directory: webapp
-        run: uv run playwright install --with-deps chromium
+        run: uv run playwright install chromium
 
       - name: Run E2E tests
         working-directory: webapp


### PR DESCRIPTION
## Summary
- Enable `astral-sh/setup-uv@v7` caching on `test-webapp` and `e2e` jobs, keyed on `webapp/uv.lock`
- Cache `~/.cache/ms-playwright` on the `e2e` job, keyed on `webapp/uv.lock` so it invalidates when Playwright bumps via Dependabot or manual edit
- `restore-keys` fallback so an unrelated `uv.lock` change doesn't force a full Chromium re-download
- Split the Playwright install into `install-deps chromium` (apt, uncached) and `install chromium` (browser, cached)

Closes #316.

## Test plan
- [x] First PR run (this one): cold cache for both uv and Playwright — verify both jobs succeed
- [x] Second PR run on the branch: verify cache hits in Actions UI logs (uv + Playwright both hit on commit `1f09982`)
- [ ] Second PR run after merge to main: confirm caches are reusable from main scope by future PR branches
- [ ] Future PR that bumps Playwright in `uv.lock` (e.g. via Dependabot): verify cache miss + repopulation, then subsequent hit
- [x] Confirm `e2e` still runs end-to-end (browser launches, tests pass) on a webapp-touching PR — 12 tests pass on both cold and warm runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)