### PR TITLE
feat: E2E items 4-10 via Playwright (#312, Phase B)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,7 +355,7 @@ When implementing from a PM-produced spec or issue:
 - **Security:** All user-controlled strings rendered in HTML must pass through `escapeHtml()`. All shell commands must use `execFileSync` with argument arrays, never string interpolation. Error messages must pass through `_sanitize_error()` / `sanitizeError()` to redact API keys. XSS and injection tests exist and must stay green.
 - **No regressions:** `npm test` must pass (currently 962 tests) before any commit to main.
 - **Feature parity:** Both the VS Code extension and the webapp are production deliverables. New scoring/analytics features should be implemented in both. Security fixes (XSS, injection) apply to both `media/app.js` and `webapp/static/app.js`.
-- **E2E testing:** Every PR test plan must include manual Playwright MCP smoke testing of the webapp before merging. See the E2E Smoke Test Checklist below.
+- **E2E testing:** Webapp PRs must keep `webapp/tests/e2e/` green. CI runs the suite automatically on PRs touching `webapp/` or `shared/`. Manual Playwright MCP testing is reserved as a fallback for exploratory verification of new surfaces not yet automated. See the E2E Smoke Test Checklist below.
 
 ## Secrets handling
 
@@ -643,9 +643,16 @@ uv run pytest tests/ -v    # Runs all webapp tests (799 tests, 12 suites)
 # tests/conftest.py              — shared fixtures (TestClient, mock Anthropic, mock sessions)
 ```
 
-### E2E Smoke Test Checklist (Playwright MCP)
+### E2E Smoke Test Checklist
 
-Run before merging PRs that touch webapp UI or API. Start the server with `uv run uvicorn main:app --port 8001`, then verify:
+The 10 items below are automated under `webapp/tests/e2e/` (one Playwright file per item). CI runs the suite on PRs touching `webapp/` or `shared/`. Run locally with:
+
+```bash
+cd webapp
+uv run pytest tests/e2e/ -m e2e -v
+```
+
+Manual Playwright MCP testing remains as a fallback for exploratory verification of new surfaces not yet covered by automation. The checklist below describes the contract each automated test enforces:
 
 1. **Tab navigation** — all 7 tabs switch correctly, correct panel is visible
 2. **Settings bar visibility** — data path input shows only on Fluency Score; project dropdown shows on Fluency Score, Conversations, Config, Optimizer, Quick Wins, Usage; settings bar hidden on Recommendations

--- a/webapp/tests/e2e/README.md
+++ b/webapp/tests/e2e/README.md
@@ -3,21 +3,20 @@
 End-to-end Playwright tests that automate the manual smoke checklist from
 `CLAUDE.md`. Each test corresponds to one item in the 10-item checklist.
 
-**Status:** Phase A — infrastructure + 3 of 10 items implemented (#312).
-Remaining 7 items land in Phase B.
+**Status:** Complete — all 10 checklist items automated (#312).
 
-| # | Checklist item | File | Status |
-|---|---|---|---|
-| 1 | Tab navigation (7 tabs) | `test_tab_navigation.py` | ✅ Phase A |
-| 2 | Settings bar visibility per tab | `test_settings_bar.py` | ✅ Phase A |
-| 3 | Project dropdown populates | `test_project_dropdown.py` | ✅ Phase A |
-| 4 | Fluency scoring | `test_fluency_scoring.py` | Phase B |
-| 5 | Conversations tab | `test_conversations.py` | Phase B |
-| 6 | Config tab | `test_config.py` | Phase B |
-| 7 | Prompt Optimizer | `test_optimizer.py` | Phase B |
-| 8 | Quick Wins | `test_quickwins.py` | Phase B |
-| 9 | Usage tab | `test_usage.py` | Phase B |
-| 10 | Health endpoint | `test_health.py` | Phase B |
+| # | Checklist item | File |
+|---|---|---|
+| 1 | Tab navigation (7 tabs) | `test_tab_navigation.py` |
+| 2 | Settings bar visibility per tab | `test_settings_bar.py` |
+| 3 | Project dropdown populates | `test_project_dropdown.py` |
+| 4 | Fluency scoring | `test_fluency_scoring.py` |
+| 5 | Conversations tab | `test_conversations.py` |
+| 6 | Config tab | `test_config.py` |
+| 7 | Prompt Optimizer | `test_optimizer.py` |
+| 8 | Quick Wins | `test_quickwins.py` |
+| 9 | Usage tab | `test_usage.py` |
+| 10 | Health endpoint | `test_health.py` |
 
 ## Running locally
 
@@ -65,17 +64,17 @@ The encoded project path is built from `$HOME` so server-side path validation
 | `/api/quickwins` | Yes | Seeded data + error-path on API call |
 | `/api/optimize` | N/A (no data lookup) | Error-path on API call |
 | `/api/conversation-analytics` | Yes | Seeded data |
-| `/api/usage` | **No — uses hardcoded `DATA_DIR`** | Empty-state assertion in Phase B |
-| `/api/config-maturity` | **No — scans real `~/.claude/`** | Empty-state assertion in Phase B |
-| `/health` | N/A | Direct HTTP assertion in Phase B |
+| `/api/usage` | **No — uses hardcoded `DATA_DIR`** | Empty-state assertion |
+| `/api/config-maturity` | **No — scans real `~/.claude/`** | DOM-presence assertion (renderer always emits the score-ring + checklist) |
+| `/health` | N/A | Direct HTTP assertion |
 
-Phase B will treat empty-state rendering as itself a regression target — a
-graceful empty-state for `/api/config-maturity` and `/api/usage` is valuable
-coverage in its own right.
+Empty-state rendering is itself a regression target — a graceful empty-state
+for `/api/config-maturity` and `/api/usage` is valuable coverage in its own
+right.
 
 ## Mocking the Anthropic API
 
-**Strategy: error-path testing only (Phase B).** Tests that trigger API calls
+**Strategy: error-path testing only.** Tests that trigger API calls
 (items 4, 7, 8) run with a fake key (`sk-test-e2e-fake-key`) set by the
 server fixture. The Anthropic client constructor doesn't validate the key,
 but the API call fails. Tests assert the UI shows an error state (e.g., the

--- a/webapp/tests/e2e/_helpers.py
+++ b/webapp/tests/e2e/_helpers.py
@@ -1,0 +1,34 @@
+"""Shared interaction helpers for E2E tests.
+
+Centralizes two patterns that recurred across files:
+- `go_to_tab` so tab-button selectors live in one place
+- `expect_button_idle` so the "request lifecycle completed" idiom (button
+  label restoration is set inside a `finally`, so re-enable + label-reset
+  is our only proxy for "no unhandled exception") is documented once.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Locator, Page, expect
+
+
+def go_to_tab(page: Page, data_tab: str) -> None:
+    """Load the SPA and switch to the named tab.
+
+    `data_tab` matches the `data-tab` attribute on the tab button (single
+    source of truth in `_tabs.TABS`).
+    """
+    page.goto("/")
+    page.locator(f'button.tab[data-tab="{data_tab}"]').click()
+
+
+def expect_button_idle(btn: Locator, idle_label: str, timeout: int = 30_000) -> None:
+    """Wait for a button to return to its idle label and be enabled.
+
+    Frontend re-enables click buttons inside a `finally`, so this is the
+    most reliable signal that the request lifecycle finished cleanly. The
+    30s ceiling absorbs CI variance; Playwright resolves the moment the
+    condition is met.
+    """
+    expect(btn).to_have_text(idle_label, timeout=timeout)
+    expect(btn).to_be_enabled()

--- a/webapp/tests/e2e/test_config.py
+++ b/webapp/tests/e2e/test_config.py
@@ -1,11 +1,9 @@
 """E2E item 6: Config tab — maturity score and breakdown render.
 
-`/api/config-maturity` does not respect `CLAUDE_DATA_DIR` (architect review
-flagged this in #312). Without a project selected, the scanner runs against
-the test runner's home directory and returns a (possibly empty) maturity
-result. `renderConfigMaturity` always renders the score ring + checklist
-sections regardless of how many checks are populated, so this test is valid
-in both seeded and empty environments.
+`/api/config-maturity` runs against the host's `~/.claude/` (the endpoint
+does not respect `CLAUDE_DATA_DIR`), but `computeMaturityScore` always
+emits all 8 breakdown categories regardless of the host's state, so this
+test is environment-independent.
 """
 
 from __future__ import annotations
@@ -13,22 +11,20 @@ from __future__ import annotations
 import pytest
 from playwright.sync_api import Page, expect
 
+from ._helpers import go_to_tab
+
+EXPECTED_CATEGORY_COUNT = 8  # CLAUDE.md, Hooks, Rules, Commands, MCP, Skills, Permissions, Enforcement
+
 
 @pytest.mark.e2e
 def test_config_tab_renders_maturity_score_and_breakdown(page: Page):
-    page.goto("/")
-    page.locator('button.tab[data-tab="config"]').click()
+    go_to_tab(page, "config")
 
     container = page.locator("#config-maturity-content")
     expect(container).to_be_visible()
 
-    # Score ring renders inside the maturity score section once the request
-    # resolves; the loading empty-state is replaced.
-    expect(container.locator(".maturity-score-section")).to_be_visible(
-        timeout=15_000
-    )
+    expect(container.locator(".maturity-score-section")).to_be_visible(timeout=15_000)
     expect(container.locator(".maturity-tier")).to_be_visible()
 
-    # Checklist breakdown exists with at least one category.
     expect(container.locator(".maturity-checklist")).to_be_visible()
-    expect(container.locator(".maturity-category").first).to_be_visible()
+    expect(container.locator(".maturity-category")).to_have_count(EXPECTED_CATEGORY_COUNT)

--- a/webapp/tests/e2e/test_config.py
+++ b/webapp/tests/e2e/test_config.py
@@ -1,0 +1,34 @@
+"""E2E item 6: Config tab — maturity score and breakdown render.
+
+`/api/config-maturity` does not respect `CLAUDE_DATA_DIR` (architect review
+flagged this in #312). Without a project selected, the scanner runs against
+the test runner's home directory and returns a (possibly empty) maturity
+result. `renderConfigMaturity` always renders the score ring + checklist
+sections regardless of how many checks are populated, so this test is valid
+in both seeded and empty environments.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+
+
+@pytest.mark.e2e
+def test_config_tab_renders_maturity_score_and_breakdown(page: Page):
+    page.goto("/")
+    page.locator('button.tab[data-tab="config"]').click()
+
+    container = page.locator("#config-maturity-content")
+    expect(container).to_be_visible()
+
+    # Score ring renders inside the maturity score section once the request
+    # resolves; the loading empty-state is replaced.
+    expect(container.locator(".maturity-score-section")).to_be_visible(
+        timeout=15_000
+    )
+    expect(container.locator(".maturity-tier")).to_be_visible()
+
+    # Checklist breakdown exists with at least one category.
+    expect(container.locator(".maturity-checklist")).to_be_visible()
+    expect(container.locator(".maturity-category").first).to_be_visible()

--- a/webapp/tests/e2e/test_conversations.py
+++ b/webapp/tests/e2e/test_conversations.py
@@ -1,52 +1,40 @@
-"""E2E item 5: Conversations tab — summary cards, charts, and conversation list render.
-
-The fixture seeds one mock conversation under `CLAUDE_DATA_DIR`. When the user
-navigates to the Conversations tab, the frontend fetches
-`/api/conversation-analytics`, hydrates the explorer, and reveals the
-previously-hidden summary cards / charts / table containers.
-"""
+"""E2E item 5: Conversations tab — summary cards, charts, and conversation list render."""
 
 from __future__ import annotations
 
 import pytest
 from playwright.sync_api import Page, expect
 
+from ._helpers import go_to_tab
+
+
+CHART_CANVAS_IDS = (
+    "conv-task-type-chart",
+    "conv-per-week-chart",
+    "conv-length-chart",
+    "conv-duration-chart",
+    "conv-avg-length-chart",
+    "conv-gap-chart",
+)
+
 
 @pytest.mark.e2e
-def test_conversations_tab_renders_summary_and_table(page: Page):
-    """After tab switch, summary cards and the list table become visible."""
-    page.goto("/")
-    page.locator('button.tab[data-tab="conversations"]').click()
+def test_conversations_tab_hydrates_from_seeded_data(page: Page):
+    """After tab switch, summary cards / charts row / list table all populate.
 
-    # Loading indicator should clear once the analytics request resolves.
+    The fixture seeds one conversation; the conversations explorer should
+    reveal every previously-hidden container and emit at least one row.
+    """
+    go_to_tab(page, "conversations")
+
     expect(page.locator("#conversations-loading")).to_be_hidden(timeout=15_000)
 
-    # With seeded data, the summary cards container is revealed and at least
-    # one row appears in the conversation list.
     expect(page.locator("#conversations-summary-cards")).to_be_visible()
-    expect(page.locator("#conversations-summary-cards .pace-card").first).to_be_visible()
+    expect(page.locator("#conversations-summary-cards .pace-card")).to_have_count(4)
 
     expect(page.locator("#conversations-table-container")).to_be_visible()
-    expect(page.locator("#conversations-list-tbody tr").first).to_be_visible()
+    expect(page.locator("#conversations-list-tbody tr")).not_to_have_count(0)
 
-
-@pytest.mark.e2e
-def test_conversations_charts_row_renders(page: Page):
-    """Charts row is revealed and the task-type doughnut canvas exists."""
-    page.goto("/")
-    page.locator('button.tab[data-tab="conversations"]').click()
-
-    expect(page.locator("#conversations-loading")).to_be_hidden(timeout=15_000)
     expect(page.locator("#conversations-charts-row")).to_be_visible()
-
-    # Each chart canvas referenced by the spec must exist (item 5: task-type
-    # pie chart, conversations-per-week, length/duration/gap distributions).
-    for canvas_id in (
-        "conv-task-type-chart",
-        "conv-per-week-chart",
-        "conv-length-chart",
-        "conv-duration-chart",
-        "conv-avg-length-chart",
-        "conv-gap-chart",
-    ):
+    for canvas_id in CHART_CANVAS_IDS:
         expect(page.locator(f"#{canvas_id}")).to_be_attached()

--- a/webapp/tests/e2e/test_conversations.py
+++ b/webapp/tests/e2e/test_conversations.py
@@ -1,0 +1,52 @@
+"""E2E item 5: Conversations tab — summary cards, charts, and conversation list render.
+
+The fixture seeds one mock conversation under `CLAUDE_DATA_DIR`. When the user
+navigates to the Conversations tab, the frontend fetches
+`/api/conversation-analytics`, hydrates the explorer, and reveals the
+previously-hidden summary cards / charts / table containers.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+
+
+@pytest.mark.e2e
+def test_conversations_tab_renders_summary_and_table(page: Page):
+    """After tab switch, summary cards and the list table become visible."""
+    page.goto("/")
+    page.locator('button.tab[data-tab="conversations"]').click()
+
+    # Loading indicator should clear once the analytics request resolves.
+    expect(page.locator("#conversations-loading")).to_be_hidden(timeout=15_000)
+
+    # With seeded data, the summary cards container is revealed and at least
+    # one row appears in the conversation list.
+    expect(page.locator("#conversations-summary-cards")).to_be_visible()
+    expect(page.locator("#conversations-summary-cards .pace-card").first).to_be_visible()
+
+    expect(page.locator("#conversations-table-container")).to_be_visible()
+    expect(page.locator("#conversations-list-tbody tr").first).to_be_visible()
+
+
+@pytest.mark.e2e
+def test_conversations_charts_row_renders(page: Page):
+    """Charts row is revealed and the task-type doughnut canvas exists."""
+    page.goto("/")
+    page.locator('button.tab[data-tab="conversations"]').click()
+
+    expect(page.locator("#conversations-loading")).to_be_hidden(timeout=15_000)
+    expect(page.locator("#conversations-charts-row")).to_be_visible()
+
+    # Each chart canvas referenced by the spec must exist (item 5: task-type
+    # pie chart, conversations-per-week, length/duration/gap distributions).
+    for canvas_id in (
+        "conv-task-type-chart",
+        "conv-per-week-chart",
+        "conv-length-chart",
+        "conv-duration-chart",
+        "conv-avg-length-chart",
+        "conv-gap-chart",
+    ):
+        expect(page.locator(f"#{canvas_id}")).to_be_attached()

--- a/webapp/tests/e2e/test_fluency_scoring.py
+++ b/webapp/tests/e2e/test_fluency_scoring.py
@@ -1,0 +1,59 @@
+"""E2E item 4: Fluency scoring — Run Analysis triggers scoring and renders gracefully.
+
+The fixture seeds a fake `ANTHROPIC_API_KEY`. Anthropic returns 401 for the
+real API call; the backend catches the exception per-conversation and the
+frontend ends up rendering an empty-state ("No conversations could be scored.")
+rather than crashing. That graceful degradation is exactly what we're
+asserting — happy-path scoring requires a real key and is out of scope for
+Phase B (see #312 architect review).
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+
+
+@pytest.mark.e2e
+def test_run_analysis_completes_without_crash(page: Page):
+    """Click Run Analysis, wait for the button to re-enable, assert results render.
+
+    The button is only re-enabled inside a `finally` block, so this implicitly
+    verifies the request lifecycle completed (no unhandled exception). The
+    empty-state message in `#fluency-results` confirms the error path renders
+    cleanly.
+    """
+    page.goto("/")
+
+    btn = page.locator("#run-scoring-btn")
+    expect(btn).to_be_visible()
+    expect(btn).to_be_enabled()
+
+    btn.click()
+
+    # Button is disabled while scoring runs; wait for it to come back to
+    # "Run Analysis" once the request resolves (success or error).
+    expect(btn).to_have_text("Run Analysis", timeout=30_000)
+    expect(btn).to_be_enabled()
+
+    # With a fake API key, all conversations fail to score → backend returns
+    # aggregate without `average_score` → frontend renders the empty-state.
+    # Either the empty-state or a real result is acceptable; we just need to
+    # see SOMETHING rendered (not a blank panel).
+    fluency_results = page.locator("#fluency-results")
+    expect(fluency_results).not_to_be_empty()
+
+
+@pytest.mark.e2e
+def test_run_analysis_does_not_leave_disabled_button(page: Page):
+    """Regression guard: button must always re-enable, even on error.
+
+    A previous bug class (caught only in manual testing) was the button
+    staying disabled after a failed score, leaving the UI unrecoverable
+    without a page reload.
+    """
+    page.goto("/")
+
+    btn = page.locator("#run-scoring-btn")
+    btn.click()
+    expect(btn).to_be_enabled(timeout=30_000)

--- a/webapp/tests/e2e/test_fluency_scoring.py
+++ b/webapp/tests/e2e/test_fluency_scoring.py
@@ -1,11 +1,7 @@
-"""E2E item 4: Fluency scoring — Run Analysis triggers scoring and renders gracefully.
+"""E2E item 4: Fluency scoring renders gracefully under a fake API key.
 
-The fixture seeds a fake `ANTHROPIC_API_KEY`. Anthropic returns 401 for the
-real API call; the backend catches the exception per-conversation and the
-frontend ends up rendering an empty-state ("No conversations could be scored.")
-rather than crashing. That graceful degradation is exactly what we're
-asserting — happy-path scoring requires a real key and is out of scope for
-Phase B (see #312 architect review).
+Happy-path scoring needs a real Anthropic key; here we assert the error
+path degrades cleanly — button re-enables, results panel is non-empty.
 """
 
 from __future__ import annotations
@@ -13,47 +9,15 @@ from __future__ import annotations
 import pytest
 from playwright.sync_api import Page, expect
 
+from ._helpers import expect_button_idle, go_to_tab
+
 
 @pytest.mark.e2e
 def test_run_analysis_completes_without_crash(page: Page):
-    """Click Run Analysis, wait for the button to re-enable, assert results render.
-
-    The button is only re-enabled inside a `finally` block, so this implicitly
-    verifies the request lifecycle completed (no unhandled exception). The
-    empty-state message in `#fluency-results` confirms the error path renders
-    cleanly.
-    """
-    page.goto("/")
-
-    btn = page.locator("#run-scoring-btn")
-    expect(btn).to_be_visible()
-    expect(btn).to_be_enabled()
-
-    btn.click()
-
-    # Button is disabled while scoring runs; wait for it to come back to
-    # "Run Analysis" once the request resolves (success or error).
-    expect(btn).to_have_text("Run Analysis", timeout=30_000)
-    expect(btn).to_be_enabled()
-
-    # With a fake API key, all conversations fail to score → backend returns
-    # aggregate without `average_score` → frontend renders the empty-state.
-    # Either the empty-state or a real result is acceptable; we just need to
-    # see SOMETHING rendered (not a blank panel).
-    fluency_results = page.locator("#fluency-results")
-    expect(fluency_results).not_to_be_empty()
-
-
-@pytest.mark.e2e
-def test_run_analysis_does_not_leave_disabled_button(page: Page):
-    """Regression guard: button must always re-enable, even on error.
-
-    A previous bug class (caught only in manual testing) was the button
-    staying disabled after a failed score, leaving the UI unrecoverable
-    without a page reload.
-    """
-    page.goto("/")
+    go_to_tab(page, "fluency")
 
     btn = page.locator("#run-scoring-btn")
     btn.click()
-    expect(btn).to_be_enabled(timeout=30_000)
+
+    expect_button_idle(btn, "Run Analysis")
+    expect(page.locator("#fluency-results")).not_to_be_empty()

--- a/webapp/tests/e2e/test_health.py
+++ b/webapp/tests/e2e/test_health.py
@@ -1,0 +1,39 @@
+"""E2E item 10: Health endpoint returns status, version, and dependency checks.
+
+Direct HTTP test (no browser needed) — asserts the contract documented in
+`webapp/main.py:health()`. The fixture seeds an `ANTHROPIC_API_KEY`, so we
+expect status "ok" rather than "degraded".
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+import requests
+
+
+@pytest.mark.e2e
+def test_health_returns_status_and_version(e2e_server):
+    r = requests.get(f"{e2e_server.base_url}/health", timeout=5)
+    assert r.status_code == 200
+
+    body = r.json()
+    assert body["status"] == "ok"  # fixture sets ANTHROPIC_API_KEY
+    assert isinstance(body["version"], str) and body["version"]
+    # Sanity-check the version string looks like a real version. Allows
+    # semver, semver+suffix, or "unknown" — but rejects empty/typo'd values.
+    assert re.match(r"^(\d+\.\d+\.\d+|unknown)", body["version"])
+
+
+@pytest.mark.e2e
+def test_health_reports_dependency_checks(e2e_server):
+    r = requests.get(f"{e2e_server.base_url}/health", timeout=5)
+    body = r.json()
+
+    checks = body.get("checks")
+    assert isinstance(checks, dict)
+    assert checks["anthropic_api_key"] == "configured"
+    # data_directory may be "accessible" or "not_found" depending on host;
+    # we only assert the key is present and reports a known state.
+    assert checks["data_directory"] in ("accessible", "not_found")

--- a/webapp/tests/e2e/test_health.py
+++ b/webapp/tests/e2e/test_health.py
@@ -1,8 +1,6 @@
-"""E2E item 10: Health endpoint returns status, version, and dependency checks.
+"""E2E item 10: /health returns status, version, and dependency checks.
 
-Direct HTTP test (no browser needed) — asserts the contract documented in
-`webapp/main.py:health()`. The fixture seeds an `ANTHROPIC_API_KEY`, so we
-expect status "ok" rather than "degraded".
+Direct HTTP — the fixture seeds `ANTHROPIC_API_KEY`, so status is "ok".
 """
 
 from __future__ import annotations
@@ -19,10 +17,9 @@ def test_health_returns_status_and_version(e2e_server):
     assert r.status_code == 200
 
     body = r.json()
-    assert body["status"] == "ok"  # fixture sets ANTHROPIC_API_KEY
+    assert body["status"] == "ok"
     assert isinstance(body["version"], str) and body["version"]
-    # Sanity-check the version string looks like a real version. Allows
-    # semver, semver+suffix, or "unknown" — but rejects empty/typo'd values.
+    # Reject empty / typo'd version strings; allow semver, semver+suffix, or "unknown".
     assert re.match(r"^(\d+\.\d+\.\d+|unknown)", body["version"])
 
 
@@ -34,6 +31,5 @@ def test_health_reports_dependency_checks(e2e_server):
     checks = body.get("checks")
     assert isinstance(checks, dict)
     assert checks["anthropic_api_key"] == "configured"
-    # data_directory may be "accessible" or "not_found" depending on host;
-    # we only assert the key is present and reports a known state.
+    # data_directory is host-dependent — assert only that a known state is reported.
     assert checks["data_directory"] in ("accessible", "not_found")

--- a/webapp/tests/e2e/test_optimizer.py
+++ b/webapp/tests/e2e/test_optimizer.py
@@ -1,27 +1,20 @@
-"""E2E item 7: Prompt Optimizer — type prompt, click Optimize, results render.
-
-With a fake `ANTHROPIC_API_KEY` the backend returns 500 for `/api/optimize`;
-the frontend renders an error empty-state. We assert the error path renders
-cleanly (no crash, button re-enabled) — see #312 architect review for why
-happy-path mocking is out of scope for Phase B.
-"""
+"""E2E item 7: Prompt Optimizer — type prompt, click Optimize, results render."""
 
 from __future__ import annotations
 
 import pytest
 from playwright.sync_api import Page, expect
 
+from ._helpers import expect_button_idle, go_to_tab
+
 
 @pytest.mark.e2e
 def test_optimize_button_disabled_with_empty_input(page: Page):
-    """Empty/whitespace input must not crash; renders inline empty-state."""
-    page.goto("/")
-    page.locator('button.tab[data-tab="optimizer"]').click()
+    """Empty input short-circuits to an inline message rather than calling the API."""
+    go_to_tab(page, "optimizer")
 
-    expect(page.locator("#optimizer-textarea")).to_be_visible()
     page.locator("#optimize-btn").click()
 
-    # Frontend short-circuits and shows an inline message.
     expect(page.locator("#optimizer-results")).to_contain_text(
         "Please enter a prompt to optimize."
     )
@@ -29,31 +22,20 @@ def test_optimize_button_disabled_with_empty_input(page: Page):
 
 @pytest.mark.e2e
 def test_optimize_request_completes_without_crash(page: Page):
-    """Type a real prompt, click Optimize, wait for completion (success or error)."""
-    page.goto("/")
-    page.locator('button.tab[data-tab="optimizer"]').click()
+    go_to_tab(page, "optimizer")
 
-    textarea = page.locator("#optimizer-textarea")
-    textarea.fill("Help me refactor this function for clarity.")
+    page.locator("#optimizer-textarea").fill("Help me refactor this function for clarity.")
 
     btn = page.locator("#optimize-btn")
     btn.click()
 
-    # Re-enable indicates the request lifecycle completed without an
-    # unhandled exception (the button is restored inside a `finally`).
-    expect(btn).to_have_text("Optimize", timeout=30_000)
-    expect(btn).to_be_enabled()
-
-    # Results panel must be non-empty — either an optimized prompt rendered,
-    # an "already good" card, or a graceful error message.
+    expect_button_idle(btn, "Optimize")
     expect(page.locator("#optimizer-results")).not_to_be_empty()
 
 
 @pytest.mark.e2e
 def test_optimizer_char_counter_updates(page: Page):
-    """Typing updates the live character counter — sanity check for input wiring."""
-    page.goto("/")
-    page.locator('button.tab[data-tab="optimizer"]').click()
+    go_to_tab(page, "optimizer")
 
     counter = page.locator("#optimizer-char-count")
     expect(counter).to_have_text("0 / 10,000")

--- a/webapp/tests/e2e/test_optimizer.py
+++ b/webapp/tests/e2e/test_optimizer.py
@@ -1,0 +1,62 @@
+"""E2E item 7: Prompt Optimizer — type prompt, click Optimize, results render.
+
+With a fake `ANTHROPIC_API_KEY` the backend returns 500 for `/api/optimize`;
+the frontend renders an error empty-state. We assert the error path renders
+cleanly (no crash, button re-enabled) — see #312 architect review for why
+happy-path mocking is out of scope for Phase B.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+
+
+@pytest.mark.e2e
+def test_optimize_button_disabled_with_empty_input(page: Page):
+    """Empty/whitespace input must not crash; renders inline empty-state."""
+    page.goto("/")
+    page.locator('button.tab[data-tab="optimizer"]').click()
+
+    expect(page.locator("#optimizer-textarea")).to_be_visible()
+    page.locator("#optimize-btn").click()
+
+    # Frontend short-circuits and shows an inline message.
+    expect(page.locator("#optimizer-results")).to_contain_text(
+        "Please enter a prompt to optimize."
+    )
+
+
+@pytest.mark.e2e
+def test_optimize_request_completes_without_crash(page: Page):
+    """Type a real prompt, click Optimize, wait for completion (success or error)."""
+    page.goto("/")
+    page.locator('button.tab[data-tab="optimizer"]').click()
+
+    textarea = page.locator("#optimizer-textarea")
+    textarea.fill("Help me refactor this function for clarity.")
+
+    btn = page.locator("#optimize-btn")
+    btn.click()
+
+    # Re-enable indicates the request lifecycle completed without an
+    # unhandled exception (the button is restored inside a `finally`).
+    expect(btn).to_have_text("Optimize", timeout=30_000)
+    expect(btn).to_be_enabled()
+
+    # Results panel must be non-empty — either an optimized prompt rendered,
+    # an "already good" card, or a graceful error message.
+    expect(page.locator("#optimizer-results")).not_to_be_empty()
+
+
+@pytest.mark.e2e
+def test_optimizer_char_counter_updates(page: Page):
+    """Typing updates the live character counter — sanity check for input wiring."""
+    page.goto("/")
+    page.locator('button.tab[data-tab="optimizer"]').click()
+
+    counter = page.locator("#optimizer-char-count")
+    expect(counter).to_have_text("0 / 10,000")
+
+    page.locator("#optimizer-textarea").fill("hello")
+    expect(counter).to_have_text("5 / 10,000")

--- a/webapp/tests/e2e/test_quickwins.py
+++ b/webapp/tests/e2e/test_quickwins.py
@@ -1,10 +1,9 @@
 """E2E item 8: Quick Wins — click Generate, results section renders.
 
-The endpoint depends on `gh` CLI being authenticated AND on the Anthropic API
-returning suggestions. In E2E, both are unreliable: CI may not have `gh`
-auth, and the fake API key returns 401. The backend returns
-`{"suggestions": [], "error": "..."}` in that case and the frontend renders
-the no-suggestions empty-state. We assert that graceful degradation.
+The endpoint depends on `gh` CLI auth and a real Anthropic key; in CI both
+are unreliable, so the backend returns `{"suggestions": [], "error": ...}`
+and the frontend renders the no-suggestions empty-state. We assert the
+graceful degradation.
 """
 
 from __future__ import annotations
@@ -12,21 +11,15 @@ from __future__ import annotations
 import pytest
 from playwright.sync_api import Page, expect
 
+from ._helpers import expect_button_idle, go_to_tab
+
 
 @pytest.mark.e2e
 def test_generate_suggestions_completes_without_crash(page: Page):
-    page.goto("/")
-    page.locator('button.tab[data-tab="quickwins"]').click()
+    go_to_tab(page, "quickwins")
 
     btn = page.locator("#load-quickwins-btn")
-    expect(btn).to_be_visible()
-    expect(btn).to_be_enabled()
     btn.click()
 
-    # Re-enable indicates the request lifecycle completed (success or error).
-    expect(btn).to_have_text("Generate Suggestions", timeout=30_000)
-    expect(btn).to_be_enabled()
-
-    # Results panel must be non-empty — either rendered suggestion cards or
-    # a graceful no-suggestions empty-state.
+    expect_button_idle(btn, "Generate Suggestions")
     expect(page.locator("#quickwins-results")).not_to_be_empty()

--- a/webapp/tests/e2e/test_quickwins.py
+++ b/webapp/tests/e2e/test_quickwins.py
@@ -1,0 +1,32 @@
+"""E2E item 8: Quick Wins — click Generate, results section renders.
+
+The endpoint depends on `gh` CLI being authenticated AND on the Anthropic API
+returning suggestions. In E2E, both are unreliable: CI may not have `gh`
+auth, and the fake API key returns 401. The backend returns
+`{"suggestions": [], "error": "..."}` in that case and the frontend renders
+the no-suggestions empty-state. We assert that graceful degradation.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+
+
+@pytest.mark.e2e
+def test_generate_suggestions_completes_without_crash(page: Page):
+    page.goto("/")
+    page.locator('button.tab[data-tab="quickwins"]').click()
+
+    btn = page.locator("#load-quickwins-btn")
+    expect(btn).to_be_visible()
+    expect(btn).to_be_enabled()
+    btn.click()
+
+    # Re-enable indicates the request lifecycle completed (success or error).
+    expect(btn).to_have_text("Generate Suggestions", timeout=30_000)
+    expect(btn).to_be_enabled()
+
+    # Results panel must be non-empty — either rendered suggestion cards or
+    # a graceful no-suggestions empty-state.
+    expect(page.locator("#quickwins-results")).not_to_be_empty()

--- a/webapp/tests/e2e/test_usage.py
+++ b/webapp/tests/e2e/test_usage.py
@@ -1,0 +1,47 @@
+"""E2E item 9: Usage tab — pace cards, chart, conversation analytics render.
+
+Two data sources feed this tab:
+  - **ccusage** (global) — read from `DATA_DIR / 'ccusage' / *.json`, which
+    is empty in E2E (architect review flagged `/api/usage` does not respect
+    `CLAUDE_DATA_DIR`). Empty-state is the expected, asserted outcome.
+  - **Conversation analytics** — sourced from `CLAUDE_DATA_DIR` via
+    `/api/conversation-analytics`, which the fixture seeds. Efficiency
+    cards and the per-conversation table should populate.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+
+
+@pytest.mark.e2e
+def test_usage_tab_renders_ccusage_section(page: Page):
+    """ccusage chart container exists; empty-state shown when no data."""
+    page.goto("/")
+    page.locator('button.tab[data-tab="usage"]').click()
+
+    # Pace and chart containers are always present — they render content
+    # (or an empty-state) once `/api/usage` resolves.
+    expect(page.locator("#usage-pace")).to_be_attached()
+    expect(page.locator("#usage-chart")).to_be_attached()
+
+
+@pytest.mark.e2e
+def test_usage_tab_renders_conversation_analytics(page: Page):
+    """Conversation Analytics heading + efficiency cards populate from seeded data."""
+    page.goto("/")
+    page.locator('button.tab[data-tab="usage"]').click()
+
+    heading = page.locator("#conversation-analytics-heading")
+    expect(heading).to_be_visible()
+    expect(heading).to_contain_text("Conversation Analytics")
+
+    # Either the efficiency cards populate (seeded data resolves) or the
+    # empty-state inside the cards container shows. Both are non-empty.
+    expect(page.locator("#conversation-efficiency-cards")).not_to_be_empty(
+        timeout=15_000
+    )
+
+    # Per-conversation token table container is also wired up.
+    expect(page.locator("#conversation-token-table-container")).to_be_attached()

--- a/webapp/tests/e2e/test_usage.py
+++ b/webapp/tests/e2e/test_usage.py
@@ -1,12 +1,9 @@
 """E2E item 9: Usage tab — pace cards, chart, conversation analytics render.
 
-Two data sources feed this tab:
-  - **ccusage** (global) — read from `DATA_DIR / 'ccusage' / *.json`, which
-    is empty in E2E (architect review flagged `/api/usage` does not respect
-    `CLAUDE_DATA_DIR`). Empty-state is the expected, asserted outcome.
-  - **Conversation analytics** — sourced from `CLAUDE_DATA_DIR` via
-    `/api/conversation-analytics`, which the fixture seeds. Efficiency
-    cards and the per-conversation table should populate.
+`/api/usage` reads from a hardcoded `DATA_DIR / 'ccusage'` (does not respect
+`CLAUDE_DATA_DIR`), so the global ccusage section renders empty-state in
+E2E. The conversation-analytics section, in contrast, sources from the
+seeded `CLAUDE_DATA_DIR` and should populate.
 """
 
 from __future__ import annotations
@@ -14,34 +11,24 @@ from __future__ import annotations
 import pytest
 from playwright.sync_api import Page, expect
 
+from ._helpers import go_to_tab
+
 
 @pytest.mark.e2e
 def test_usage_tab_renders_ccusage_section(page: Page):
-    """ccusage chart container exists; empty-state shown when no data."""
-    page.goto("/")
-    page.locator('button.tab[data-tab="usage"]').click()
+    go_to_tab(page, "usage")
 
-    # Pace and chart containers are always present — they render content
-    # (or an empty-state) once `/api/usage` resolves.
     expect(page.locator("#usage-pace")).to_be_attached()
     expect(page.locator("#usage-chart")).to_be_attached()
 
 
 @pytest.mark.e2e
 def test_usage_tab_renders_conversation_analytics(page: Page):
-    """Conversation Analytics heading + efficiency cards populate from seeded data."""
-    page.goto("/")
-    page.locator('button.tab[data-tab="usage"]').click()
+    go_to_tab(page, "usage")
 
     heading = page.locator("#conversation-analytics-heading")
     expect(heading).to_be_visible()
     expect(heading).to_contain_text("Conversation Analytics")
 
-    # Either the efficiency cards populate (seeded data resolves) or the
-    # empty-state inside the cards container shows. Both are non-empty.
-    expect(page.locator("#conversation-efficiency-cards")).not_to_be_empty(
-        timeout=15_000
-    )
-
-    # Per-conversation token table container is also wired up.
+    expect(page.locator("#conversation-efficiency-cards")).not_to_be_empty(timeout=15_000)
     expect(page.locator("#conversation-token-table-container")).to_be_attached()


### PR DESCRIPTION
Closes the manual-checklist work in #312 by automating items 4-10. Phase A (#315) landed the Playwright dep, conftest server fixture, CI job, path filter, and items 1-3 — this PR fills in the remaining 7 items and flips CLAUDE.md to treat the automated suite as the primary E2E verification.

## Summary
- **7 new test files** under `webapp/tests/e2e/` covering items 4-10 (fluency scoring, conversations, config, optimizer, quickwins, usage, health).
- **Error-path coverage** for the Anthropic-dependent endpoints (items 4/7/8) — the fixture's fake key forces a 401, and the tests assert the UI re-enables buttons + renders graceful empty/error states (no crashes, no stuck spinners).
- **DOM-presence coverage** for the data-hydration tabs (items 5/6/9) — seeded `CLAUDE_DATA_DIR` populates conversation analytics; `/api/config-maturity` runs against the host's home-only state but its renderer always emits the score ring + checklist regardless.
- **Direct HTTP** for `/health` (item 10) — asserts contract (status, version, dependency-checks dict).
- **Docs:** `CLAUDE.md` E2E section now points at `webapp/tests/e2e/` as primary; manual Playwright MCP is reserved as a fallback. The e2e `README.md` table is refreshed to mark the suite complete.

## Test plan
- [x] `uv run pytest tests/e2e/ -m e2e -v` — 25/25 passed in ~30s
- [x] `uv run pytest tests/` (default markers) — 796/796 passed, no regressions
- [x] Verify CI `e2e` job runs on this PR (touches `webapp/`)
- [ ] Verify CI `e2e` job is skipped on a docs-only follow-up

## Notes
- Items 4/7/8 do **not** mock the Anthropic API; happy-path coverage was deferred per the architect review on #312 (would require an `ANTHROPIC_BASE_URL` override + HTTP mock server).
- Item 6 (Config) does not seed mock `.claude/` content — the test asserts that the renderer always produces the score-ring + checklist DOM, which is true regardless of whether any maturity signals are present. This matches the architect's note that empty-state rendering is itself a regression target.
- Item 9 (Usage) treats the ccusage section as empty-state (it reads from a hardcoded `DATA_DIR / "ccusage"` not affected by `CLAUDE_DATA_DIR`) and asserts the conversation-analytics half hydrates from the seeded data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)