### PR TITLE
ci: drop playwright install-deps, pin e2e to ubuntu-24.04 (#319)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,10 @@ jobs:
     name: Run E2E Tests
     needs: changes
     if: needs.changes.outputs.webapp == 'true'
-    runs-on: ubuntu-latest
+    # Pinned (rather than ubuntu-latest) so a future runner-image bump that
+    # drops a library Chromium needs becomes an explicit, reviewable change
+    # instead of silent CI breakage. See #319.
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v6
@@ -124,10 +127,17 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-
 
-      - name: Install Playwright system dependencies
-        working-directory: webapp
-        run: uv run playwright install-deps chromium
-
+      # `playwright install-deps` is intentionally omitted: ubuntu-24.04
+      # already ships the runtime libs Chromium needs (libnss3, libgtk-3-0,
+      # libasound2, libgbm1, libxkbcommon0, libxcomposite1, libxdamage1,
+      # libxfixes3, libcups2, libpango-1.0-0). The packages it would otherwise
+      # apt-install are mostly Asian/Cyrillic font sets (fonts-ipafont-gothic,
+      # fonts-wqy-zenhei, xfonts-cyrillic, etc.) that Latin-only test fixtures
+      # never exercise. A 17-minute apt stall + failure on PR #318 (issue
+      # #319) was caused by exactly that mirror flaking. If a missing-lib
+      # error ever surfaces, add a single
+      # `apt-get install -y --no-install-recommends <lib>` step rather than
+      # reinstating the full font bundle.
       - name: Install Playwright browser
         working-directory: webapp
         run: uv run playwright install chromium


### PR DESCRIPTION
Closes #319.

## Summary
- **Drop `Install Playwright system dependencies` step** in `.github/workflows/ci.yml`. ubuntu-24.04 already ships the libs Chromium needs at runtime; the packages `install-deps` was fetching were mostly Asian/Cyrillic font sets (fonts-ipafont-gothic, fonts-wqy-zenhei, xfonts-cyrillic, ...) that our Latin-only test fixtures never exercise.
- **Pin the e2e job from `ubuntu-latest` to `ubuntu-24.04`** so a future runner-image change that drops a load-bearing library becomes an explicit, reviewable bump rather than silent breakage. (Architect recommendation on #319.)

## Why now
PR #318's e2e job stalled 17m32s on `playwright install-deps chromium` and ultimately failed when `azure.archive.ubuntu.com` went unreachable. `apt-get` retried with backoff for the full duration before exiting with code 100. The same mirror dependency exists on every webapp PR going forward — exactly the surface E2E was supposed to *help* keep moving.

## Watch list during validation
1. **Did Phase A's 12 e2e tests pass on this PR?** ✅ `12 passed in 5.57s` — see [job log](https://github.com/frederick-douglas-pearce/codefluent/actions/runs/25239302316/job/74011959061).
2. **Did `Install Playwright browser` log anything about installing dependencies?** ✅ No — cache hit, instant, no install-deps re-trigger. `PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1` not needed.
3. **Is the wall-clock under 3 min?** ✅ **26 seconds** (vs the prior 17m32s failure on PR #318).

## Test plan
- [x] CI's `Run E2E Tests` job runs on this PR (paths-filter includes `.github/workflows/ci.yml` in the `webapp` filter — confirmed)
- [x] e2e job completes in under 3 minutes wall clock — **26s**
- [x] All 12 Phase A tests pass
- [x] No "Failed to install browser dependencies" or fontconfig warnings in pytest output
- [x] _Post-merge:_ rebase #318 onto main, confirm the full 23-test surface also passes under the new config

## Rollback plan
If a runtime "missing libXXX" error surfaces, add a single `apt-get install -y --no-install-recommends <libXXX>` step rather than reinstating the full font bundle.

## Architect review

Posted on #319, [comment 4362375180](https://github.com/frederick-douglas-pearce/codefluent/issues/319#issuecomment-4362375180). Caught a blocking issue with my original plan (PR target), recommended the ubuntu-24.04 pin, flagged the Playwright auto-install-deps gotcha to watch for. All addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)