### PR TITLE
ci: use PAT for release-please so PRs trigger CI (#305)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # PAT (not GITHUB_TOKEN) so PR `opened`/`synchronize` events trigger
+          # downstream workflows like ci.yml. See #305.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       # Release Please bumps webapp/pyproject.toml via the generic updater but
       # has no concept of uv lockfiles. Without this, every release leaves
@@ -34,7 +37,9 @@ jobs:
       - name: Sync webapp/uv.lock on release PR
         if: steps.release.outputs.prs_created == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Same PAT as the release-please step so this push triggers CI on
+          # the release PR (GITHUB_TOKEN-pushed commits do not). See #305.
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           PR_JSON: ${{ steps.release.outputs.pr }}
         run: |
           set -euo pipefail

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,28 @@ Example: `feat: add session token analytics to Usage tab (#89)`
 
 [Release Please](https://github.com/googleapis/release-please) uses these prefixes to auto-generate changelogs and determine version bumps. Only `feat` and `fix` commits appear in the changelog by default.
 
+## Release Secrets
+
+The release automation requires two repository secrets:
+
+| Secret | Used by | Purpose |
+|--------|---------|---------|
+| `RELEASE_PLEASE_TOKEN` | `release-please.yml` | Fine-grained PAT so release-please PRs and the `uv.lock` auto-sync commit trigger `ci.yml`. The default `GITHUB_TOKEN` cannot do this — by [GitHub's loop-prevention rule](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow), workflows triggered by `GITHUB_TOKEN` do not trigger downstream workflows, so without this PAT branch protection (`Run Tests` is required) silently blocks the release PR merge. |
+| `VSCE_PAT` | `release-please.yml` (build-release job) | VS Code Marketplace publish token. |
+
+### Rotating `RELEASE_PLEASE_TOKEN`
+
+GitHub caps fine-grained PAT lifetimes (max 1 year). Set a calendar reminder before expiration. To rotate:
+
+1. At https://github.com/settings/personal-access-tokens, generate a new fine-grained PAT scoped to **only** the `codefluent` repo with these repository permissions:
+   - **Contents:** Read and write
+   - **Pull requests:** Read and write
+   - **Workflows:** Read and write (release-please may touch `.github/workflows/` paths, e.g. `x-release-please-version` markers)
+2. `gh secret set RELEASE_PLEASE_TOKEN --repo frederick-douglas-pearce/codefluent`
+3. Revoke the old PAT in GitHub settings.
+
+If the PAT expires before rotation, the next `release-please.yml` run will fail with an auth error — rotate the secret and re-run.
+
 ## Code Conventions
 
 ### TypeScript (extension — `vscode-extension/src/`)


### PR DESCRIPTION
## Summary
- Pass `RELEASE_PLEASE_TOKEN` (fine-grained PAT) to `release-please-action@v5` via `with: token:` so the release PR's `opened`/`synchronize` events trigger `ci.yml`
- Use the same PAT for the `webapp/uv.lock` auto-sync step's `git push`, so that commit also retriggers CI (resolves the caveat noted in #296)
- Add a "Release Secrets" section to `CONTRIBUTING.md` documenting the secret's purpose, required permissions, and rotation steps

## Why

GitHub's [loop-prevention rule](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) prevents `GITHUB_TOKEN`-triggered events from running downstream workflows. `release-please-action` was opening PRs with the default token, so `ci.yml` never fired on PR open. Branch protection (`Run Tests` is required) then silently blocked the merge until the PR was manually closed/reopened or `update-branch`d. This bit us on v1.2.0 (#230) and v1.2.1 (#304).

The `build-release` job's `GITHUB_TOKEN` usages (`gh release upload`, `gh release edit --draft=false`) are intentionally unchanged — those don't need to trigger downstream workflows.

Closes #305.

## Test plan
- [x] CONTRIBUTING.md renders correctly on GitHub
- [x] **CI passes on this PR** (this validates `ci.yml` itself isn't broken — but does NOT validate the fix, since this is a normal PR opened by a maintainer, not by `release-please-action`)
- [ ] **End-to-end verification deferred to next release:** when release-please opens the next release PR, confirm `ci.yml` fires automatically without manual close/reopen and the `uv.lock` auto-sync commit also retriggers it

🤖 Generated with [Claude Code](https://claude.com/claude-code)