### PR TITLE
feat: extract system message subtypes for context/efficiency metrics (#160)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ npm run compile            # One-shot TypeScript compilation
 npm run watch              # Continuous compilation
 
 # Test
-npm test                   # Jest (unit + integration, 997 tests)
+npm test                   # Jest (unit + integration, 1019 tests)
 
 # Package and install
 npx @vscode/vsce package --allow-missing-repository
@@ -295,7 +295,7 @@ chore: bump @anthropic-ai/sdk to 0.52.0
 4. Release Please creates the git tag → triggers `release.yml` → builds VSIX → publishes to Marketplace
 
 ### CI Workflows
-- **`ci.yml`** — Runs on every PR: `npm test` (997 tests) + `vsce package` (catches `engines.vscode` / `@types/vscode` mismatches and `.vscodeignore` misconfig pre-merge) in `vscode-extension/`, `uv lock --check` + `pytest` (831 tests) in `webapp/` — `uv lock --check` fails the PR if `webapp/uv.lock` has drifted from `pyproject.toml`
+- **`ci.yml`** — Runs on every PR: `npm test` (1019 tests) + `vsce package` (catches `engines.vscode` / `@types/vscode` mismatches and `.vscodeignore` misconfig pre-merge) in `vscode-extension/`, `uv lock --check` + `pytest` (853 tests) in `webapp/` — `uv lock --check` fails the PR if `webapp/uv.lock` has drifted from `pyproject.toml`
 - **`eval.yml`** — Runs on PRs touching `shared/prompts/**`, `shared/defaults.json`, or `shared/eval/scorer.py`: scores golden set (79 CI entries / 84 total) via Anthropic API, validates schema + agreement (~$0.30/run). Skipped for Dependabot.
 - **`security-review.yml`** — Claude-powered security review via `anthropics/claude-code-security-review`. Triggered by `needs-security-review` label on PR (not on every push, to control API costs). Skipped on docs-only PRs and Dependabot. Scans webview (`media/app.js`), webapp (`webapp/`), and project Claude config (`.claude/hooks/`, `.claude/settings.json`, `.claude/agents/`).
 - **`claude-review.yml`** — AI code review via `claude-code-action@v1`. Triggered by `needs-review` label on PR (not on every push, to control API costs). Also responds to `@claude` mentions in PR comments.
@@ -355,7 +355,7 @@ When implementing from a PM-produced spec or issue:
 ## Production Standards
 - **All new features must have tests.** No merging without test coverage for the change.
 - **Security:** All user-controlled strings rendered in HTML must pass through `escapeHtml()`. All shell commands must use `execFileSync` with argument arrays, never string interpolation. Error messages must pass through `_sanitize_error()` / `sanitizeError()` to redact API keys. XSS and injection tests exist and must stay green.
-- **No regressions:** `npm test` must pass (currently 997 tests) before any commit to main.
+- **No regressions:** `npm test` must pass (currently 1019 tests) before any commit to main.
 - **Feature parity:** Both the VS Code extension and the webapp are production deliverables. New scoring/analytics features should be implemented in both. Security fixes (XSS, injection) apply to both `media/app.js` and `webapp/static/app.js`.
 - **E2E testing:** Webapp PRs must keep `webapp/tests/e2e/` green. CI runs the suite automatically on PRs touching `webapp/` or `shared/`. Manual Playwright MCP testing is reserved as a fallback for exploratory verification of new surfaces not yet automated. See the E2E Smoke Test Checklist below.
 
@@ -627,7 +627,7 @@ npm test                   # Runs all 907 Jest tests (23 suites)
 # test/__mocks__/vscode.ts                     — VS Code API mock for Jest
 
 cd ../webapp
-uv run pytest tests/ -v    # Runs all webapp tests (831 tests, 12 suites)
+uv run pytest tests/ -v    # Runs all webapp tests (853 tests, 12 suites)
 
 # Test structure:
 # tests/test_conversations.py    — conversation assembly, gap-based splitting, boundary detection

--- a/README.md
+++ b/README.md
@@ -448,10 +448,10 @@ The project has **1761 automated tests** across both interfaces:
 
 ```bash
 cd vscode-extension
-npm test                   # 997 tests across 25 suites (Jest)
+npm test                   # 1019 tests across 25 suites (Jest)
 
 cd webapp
-uv run pytest tests/ -v    # 831 tests across 13 suites (pytest)
+uv run pytest tests/ -v    # 853 tests across 13 suites (pytest)
 ```
 
 Test suites cover scoring, parsing, caching, analytics, pricing, agent metrics, task classification, anti-pattern detection, configuration scanning, enforcement gaps, XSS prevention, shell injection, path traversal, rate limiting, CORS, API surface, and scoring prompt regression testing. The eval framework (`shared/eval/`) validates scoring outputs against a [golden set of 84 curated entries](shared/eval/README.md). All tests must pass before merging to main.

--- a/vscode-extension/src/conversation.ts
+++ b/vscode-extension/src/conversation.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
-import { TimestampedMessage, SessionMessagesResult, parseSessionMessages, scanSubagentTokens } from './parser'
+import { TimestampedMessage, SessionMessagesResult, SessionSystemEvent, parseSessionMessages, scanSubagentTokens } from './parser'
 import { classifyTask } from './taskClassification'
 import { detectStructuredOutputAntiPattern } from './antiPatterns'
 import { computeConversationErrorRecovery } from './errorRecovery'
@@ -49,6 +49,13 @@ export interface ParsedConversation {
   total_tokens: number
   tokens_per_prompt: number
   cache_hit_rate: number
+  compact_count: number
+  compact_trigger_manual: number
+  compact_trigger_auto: number
+  turn_count: number
+  total_turn_duration_ms: number
+  avg_turn_duration_ms: number | null
+  local_command_count: number
 }
 
 export interface ConversationsResult {
@@ -234,6 +241,13 @@ export function buildConversations(
       total_tokens: totalTokens,
       tokens_per_prompt: tokensPerPrompt,
       cache_hit_rate: cacheHitRate,
+      compact_count: 0,
+      compact_trigger_manual: 0,
+      compact_trigger_auto: 0,
+      turn_count: 0,
+      total_turn_duration_ms: 0,
+      avg_turn_duration_ms: null,
+      local_command_count: 0,
     })
   }
 
@@ -244,6 +258,56 @@ export function buildConversations(
   }
 
   return conversations
+}
+
+/**
+ * Attribute timestamped system events to the conversation whose time range
+ * contains the event, or — if the event falls between conversations — to the
+ * nearest preceding conversation. Events with no preceding conversation are
+ * dropped. Mutates the conversations in place.
+ */
+export function attributeSystemEvents(
+  conversations: ParsedConversation[],
+  systemEvents: SessionSystemEvent[],
+): void {
+  if (conversations.length === 0 || systemEvents.length === 0) return
+
+  const sorted = [...conversations]
+    .filter(c => c.started_at)
+    .sort((a, b) => (a.started_at as string).localeCompare(b.started_at as string))
+
+  for (const event of systemEvents) {
+    if (!event.timestamp) continue
+    let target: ParsedConversation | null = null
+    for (const conv of sorted) {
+      if ((conv.started_at as string).localeCompare(event.timestamp) <= 0) {
+        target = conv
+      } else {
+        break
+      }
+    }
+    if (!target) continue
+
+    if (event.subtype === 'compact_boundary') {
+      target.compact_count++
+      if (event.trigger === 'manual') {
+        target.compact_trigger_manual++
+      } else {
+        target.compact_trigger_auto++
+      }
+    } else if (event.subtype === 'turn_duration') {
+      target.turn_count++
+      target.total_turn_duration_ms += event.duration_ms || 0
+    } else if (event.subtype === 'local_command') {
+      target.local_command_count++
+    }
+  }
+
+  for (const conv of conversations) {
+    conv.avg_turn_duration_ms = conv.turn_count > 0
+      ? conv.total_turn_duration_ms / conv.turn_count
+      : null
+  }
 }
 
 export function getAllConversations(
@@ -312,19 +376,22 @@ export function getAllConversations(
   }
 
   // Group messages by project_path_encoded
-  const byProject = new Map<string, { project: string; encoded: string; messages: TimestampedMessage[] }>()
+  const byProject = new Map<string, { project: string; encoded: string; messages: TimestampedMessage[]; systemEvents: SessionSystemEvent[] }>()
   for (const result of parsed) {
     const key = result.project_path_encoded
     if (!byProject.has(key)) {
-      byProject.set(key, { project: result.project, encoded: key, messages: [] })
+      byProject.set(key, { project: result.project, encoded: key, messages: [], systemEvents: [] })
     }
-    byProject.get(key)!.messages.push(...result.messages)
+    const bucket = byProject.get(key)!
+    bucket.messages.push(...result.messages)
+    bucket.systemEvents.push(...result.system_events)
   }
 
-  // Build conversations per project
+  // Build conversations per project, then attribute system events
   let allConversations: ParsedConversation[] = []
-  for (const { project: proj, encoded, messages } of byProject.values()) {
+  for (const { project: proj, encoded, messages, systemEvents } of byProject.values()) {
     const convs = buildConversations(messages, proj, encoded, gap)
+    attributeSystemEvents(convs, systemEvents)
     allConversations.push(...convs)
   }
 

--- a/vscode-extension/src/parser.ts
+++ b/vscode-extension/src/parser.ts
@@ -64,8 +64,16 @@ export interface TimestampedMessage {
   git_branch?: string
 }
 
+export interface SessionSystemEvent {
+  subtype: 'compact_boundary' | 'turn_duration' | 'local_command'
+  timestamp: string | null
+  trigger?: string | null   // compact_boundary only; raw value preserved (e.g. 'manual')
+  duration_ms?: number      // turn_duration only
+}
+
 export interface SessionMessagesResult {
   messages: TimestampedMessage[]
+  system_events: SessionSystemEvent[]
   session_id: string
   project: string
   project_path_encoded: string
@@ -356,6 +364,7 @@ export function parseSessionMessages(filepath: string): SessionMessagesResult | 
   let gitBranch: string | null = null
 
   const messages: TimestampedMessage[] = []
+  const systemEvents: SessionSystemEvent[] = []
 
   // Deduplication: Claude Code emits multiple assistant messages per API call
   // (streaming snapshots). Per Anthropic docs, deduplicate by message.id and
@@ -375,6 +384,38 @@ export function parseSessionMessages(filepath: string): SessionMessagesResult | 
   for (let i = 0; i < lines.length; i++) {
     const msg = lines[i]
     const msgType = msg.type || ''
+
+    // Extract `system` subtypes for context/efficiency metrics. Must run
+    // before SKIP_TYPES gate and before metadata defaults so a system row
+    // can't overwrite the canonical sessionId/version/etc. (See #160.)
+    if (msgType === 'system') {
+      if (msg.isSidechain === true) isSidechain = true
+      const subtype = msg.subtype
+      if (subtype === 'compact_boundary') {
+        const rawTrigger = msg.compactMetadata?.trigger
+        systemEvents.push({
+          subtype: 'compact_boundary',
+          timestamp: msg.timestamp || null,
+          trigger: typeof rawTrigger === 'string' ? rawTrigger : null,
+        })
+      } else if (subtype === 'turn_duration') {
+        systemEvents.push({
+          subtype: 'turn_duration',
+          timestamp: msg.timestamp || null,
+          duration_ms: typeof msg.durationMs === 'number' ? msg.durationMs : 0,
+        })
+      } else if (subtype === 'local_command') {
+        // Pair-emitted with stdout/stderr companion entries; only count invocations.
+        const content = typeof msg.content === 'string' ? msg.content : ''
+        if (content.includes('<command-name>')) {
+          systemEvents.push({
+            subtype: 'local_command',
+            timestamp: msg.timestamp || null,
+          })
+        }
+      }
+      continue
+    }
 
     if (SKIP_TYPES.has(msgType)) continue
 
@@ -581,6 +622,7 @@ export function parseSessionMessages(filepath: string): SessionMessagesResult | 
 
   return {
     messages,
+    system_events: systemEvents,
     session_id: sessionId,
     project: projectName,
     project_path_encoded: projectPathEncoded,

--- a/vscode-extension/test/unit/agentMetrics.test.ts
+++ b/vscode-extension/test/unit/agentMetrics.test.ts
@@ -44,6 +44,13 @@ function makeConversation(overrides: Partial<ParsedConversation> = {}): ParsedCo
     total_tokens: 2500,
     tokens_per_prompt: 1250,
     cache_hit_rate: 0.4,
+    compact_count: 0,
+    compact_trigger_manual: 0,
+    compact_trigger_auto: 0,
+    turn_count: 0,
+    total_turn_duration_ms: 0,
+    avg_turn_duration_ms: null,
+    local_command_count: 0,
     ...overrides,
   }
 }

--- a/vscode-extension/test/unit/conversation.test.ts
+++ b/vscode-extension/test/unit/conversation.test.ts
@@ -5,7 +5,8 @@ import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import { parseSessionMessages, TimestampedMessage } from '../../src/parser'
-import { buildConversations, getAllConversations, ParsedConversation, computeContentHash } from '../../src/conversation'
+import { buildConversations, getAllConversations, ParsedConversation, computeContentHash, attributeSystemEvents } from '../../src/conversation'
+import { SessionSystemEvent } from '../../src/parser'
 
 const mockFs = fs as jest.Mocked<typeof fs>
 const mockOs = os as jest.Mocked<typeof os>
@@ -1252,5 +1253,293 @@ describe('buildConversations commands_used', () => {
     ]
     const convs = buildConversations(messages, 'test', '-test', 60)
     expect(convs[0].commands_used).toEqual([])
+  })
+})
+
+// ─── parseSessionMessages — system event extraction ──────────────────
+
+describe('parseSessionMessages system event extraction', () => {
+  beforeEach(() => { jest.clearAllMocks() })
+
+  function systemMsg(subtype: string, extra: Record<string, any> = {}): any {
+    return {
+      type: 'system', subtype, timestamp: '2026-03-01T10:00:30.000Z',
+      sessionId: 'sess-1', cwd: '/project', isSidechain: false, ...extra,
+    }
+  }
+
+  it('extracts compact_boundary with manual trigger', () => {
+    mockFs.readFileSync.mockReturnValue(jsonl(
+      userMsg('Hello'),
+      systemMsg('compact_boundary', { compactMetadata: { trigger: 'manual', preTokens: 100000, postTokens: 5000 } }),
+      assistantMsg(),
+    ))
+    const result = parseSessionMessages('/fake/project/session.jsonl')
+    expect(result).not.toBeNull()
+    expect(result!.system_events).toHaveLength(1)
+    expect(result!.system_events[0]).toEqual({
+      subtype: 'compact_boundary',
+      timestamp: '2026-03-01T10:00:30.000Z',
+      trigger: 'manual',
+    })
+  })
+
+  it('preserves raw trigger string for non-manual compacts', () => {
+    mockFs.readFileSync.mockReturnValue(jsonl(
+      userMsg('Hello'),
+      systemMsg('compact_boundary', { compactMetadata: { trigger: 'auto-threshold' } }),
+    ))
+    const result = parseSessionMessages('/fake/project/session.jsonl')
+    expect(result!.system_events[0].trigger).toBe('auto-threshold')
+  })
+
+  it('handles compact_boundary with missing compactMetadata', () => {
+    mockFs.readFileSync.mockReturnValue(jsonl(
+      userMsg('Hello'),
+      systemMsg('compact_boundary'),
+    ))
+    const result = parseSessionMessages('/fake/project/session.jsonl')
+    expect(result!.system_events[0]).toEqual({
+      subtype: 'compact_boundary',
+      timestamp: '2026-03-01T10:00:30.000Z',
+      trigger: null,
+    })
+  })
+
+  it('extracts turn_duration with durationMs', () => {
+    mockFs.readFileSync.mockReturnValue(jsonl(
+      userMsg('Hello'),
+      systemMsg('turn_duration', { durationMs: 12345, messageCount: 8 }),
+    ))
+    const result = parseSessionMessages('/fake/project/session.jsonl')
+    expect(result!.system_events[0]).toEqual({
+      subtype: 'turn_duration',
+      timestamp: '2026-03-01T10:00:30.000Z',
+      duration_ms: 12345,
+    })
+  })
+
+  it('defaults turn_duration to 0 when durationMs missing', () => {
+    mockFs.readFileSync.mockReturnValue(jsonl(
+      userMsg('Hello'),
+      systemMsg('turn_duration'),
+    ))
+    const result = parseSessionMessages('/fake/project/session.jsonl')
+    expect(result!.system_events[0].duration_ms).toBe(0)
+  })
+
+  it('extracts local_command invocations only, filtering stdout companions', () => {
+    mockFs.readFileSync.mockReturnValue(jsonl(
+      userMsg('Hello'),
+      systemMsg('local_command', { content: '<command-name>/mcp</command-name>' }),
+      systemMsg('local_command', { content: '<local-command-stdout>output here</local-command-stdout>', timestamp: '2026-03-01T10:00:31.000Z' }),
+      systemMsg('local_command', { content: '<local-command-stderr>err</local-command-stderr>', timestamp: '2026-03-01T10:00:32.000Z' }),
+      systemMsg('local_command', { content: '<command-name>/init</command-name>', timestamp: '2026-03-01T10:00:33.000Z' }),
+    ))
+    const result = parseSessionMessages('/fake/project/session.jsonl')
+    expect(result!.system_events).toHaveLength(2)
+    expect(result!.system_events.every(e => e.subtype === 'local_command')).toBe(true)
+  })
+
+  it('skips out-of-scope system subtypes', () => {
+    mockFs.readFileSync.mockReturnValue(jsonl(
+      userMsg('Hello'),
+      systemMsg('api_error', { content: 'rate limited' }),
+      systemMsg('away_summary'),
+      systemMsg('informational'),
+      systemMsg('scheduled_task_fire'),
+      systemMsg('stop_hook_summary'),
+    ))
+    const result = parseSessionMessages('/fake/project/session.jsonl')
+    expect(result!.system_events).toHaveLength(0)
+  })
+
+  it('keeps system events out of the messages array', () => {
+    mockFs.readFileSync.mockReturnValue(jsonl(
+      userMsg('Hello'),
+      systemMsg('compact_boundary', { compactMetadata: { trigger: 'manual' } }),
+      systemMsg('turn_duration', { durationMs: 1000 }),
+      assistantMsg(),
+    ))
+    const result = parseSessionMessages('/fake/project/session.jsonl')
+    expect(result!.messages.some(m => m.type === 'system')).toBe(false)
+    expect(result!.system_events).toHaveLength(2)
+  })
+
+  it('returns null for sidechain even when system messages present', () => {
+    mockFs.readFileSync.mockReturnValue(jsonl(
+      userMsg('Hello', { isSidechain: true }),
+      systemMsg('compact_boundary', { isSidechain: true, compactMetadata: { trigger: 'manual' } }),
+    ))
+    expect(parseSessionMessages('/fake/project/session.jsonl')).toBeNull()
+  })
+
+  it('detects sidechain from system message alone', () => {
+    mockFs.readFileSync.mockReturnValue(jsonl(
+      systemMsg('compact_boundary', { isSidechain: true, compactMetadata: { trigger: 'manual' } }),
+      assistantMsg({ isSidechain: true }),
+    ))
+    expect(parseSessionMessages('/fake/project/session.jsonl')).toBeNull()
+  })
+
+  it('returns empty system_events array when no system messages present', () => {
+    mockFs.readFileSync.mockReturnValue(jsonl(
+      userMsg('Hello'),
+      assistantMsg(),
+    ))
+    const result = parseSessionMessages('/fake/project/session.jsonl')
+    expect(result!.system_events).toEqual([])
+  })
+
+  it('does not let system messages overwrite session metadata', () => {
+    // System message arrives first with different cwd/version; canonical values
+    // should come from the first non-system message.
+    mockFs.readFileSync.mockReturnValue(jsonl(
+      systemMsg('compact_boundary', { cwd: '/wrong/path', version: 'wrong', compactMetadata: { trigger: 'manual' } }),
+      userMsg('Hello', { cwd: '/right/project', version: '2.1.100' }),
+    ))
+    const result = parseSessionMessages('/fake/project/session.jsonl')
+    expect(result!.project).toBe('project')  // path.basename('/right/project')
+    const userMessage = result!.messages.find(m => m.type === 'user')
+    expect(userMessage!.claude_code_version).toBe('2.1.100')
+  })
+})
+
+// ─── attributeSystemEvents ──────────────────────────────────────────
+
+describe('attributeSystemEvents', () => {
+  function makeConv(id: string, startedAt: string, endedAt: string): ParsedConversation {
+    return {
+      id, content_hash: 'hash', project: 'proj', project_path_encoded: '-proj',
+      session_ids: ['s'], started_at: startedAt, ended_at: endedAt,
+      user_prompts: ['p'], prompt_timestamps: [startedAt], prompt_count: 1,
+      user_message_count: 1, assistant_message_count: 1, tool_use_count: 0,
+      tools_used: [], commands_used: [], thinking_count: 0, used_plan_mode: false,
+      model: null, claude_code_version: null, git_branch: null,
+      heuristic_task_type: null, has_structured_output_antipattern: false,
+      structured_output_antipattern_count: 0, error_count: 0, recovery_count: 0,
+      avg_failure_to_resolution_turns: null, recovery_strategy_diversity: 0,
+      error_tools: [], edits_count: 0, reviewed_edits: 0, commits_count: 0,
+      tested_commits: 0, review_before_accept_rate: 0, test_before_commit_rate: 0,
+      total_input_tokens: 0, total_output_tokens: 0, total_cache_creation_tokens: 0,
+      total_cache_read_tokens: 0, total_tokens: 0, tokens_per_prompt: 0, cache_hit_rate: 0,
+      compact_count: 0, compact_trigger_manual: 0, compact_trigger_auto: 0,
+      turn_count: 0, total_turn_duration_ms: 0, avg_turn_duration_ms: null,
+      local_command_count: 0,
+    }
+  }
+
+  it('attributes a compact event to the conversation containing its timestamp', () => {
+    const convs = [makeConv('c0', '2026-03-01T10:00:00Z', '2026-03-01T10:30:00Z')]
+    const events: SessionSystemEvent[] = [
+      { subtype: 'compact_boundary', timestamp: '2026-03-01T10:15:00Z', trigger: 'manual' },
+    ]
+    attributeSystemEvents(convs, events)
+    expect(convs[0].compact_count).toBe(1)
+    expect(convs[0].compact_trigger_manual).toBe(1)
+    expect(convs[0].compact_trigger_auto).toBe(0)
+  })
+
+  it('buckets non-manual triggers as auto', () => {
+    const convs = [makeConv('c0', '2026-03-01T10:00:00Z', '2026-03-01T10:30:00Z')]
+    const events: SessionSystemEvent[] = [
+      { subtype: 'compact_boundary', timestamp: '2026-03-01T10:15:00Z', trigger: 'auto-threshold' },
+      { subtype: 'compact_boundary', timestamp: '2026-03-01T10:20:00Z', trigger: null },
+    ]
+    attributeSystemEvents(convs, events)
+    expect(convs[0].compact_count).toBe(2)
+    expect(convs[0].compact_trigger_manual).toBe(0)
+    expect(convs[0].compact_trigger_auto).toBe(2)
+  })
+
+  it('aggregates turn_duration and computes average', () => {
+    const convs = [makeConv('c0', '2026-03-01T10:00:00Z', '2026-03-01T10:30:00Z')]
+    const events: SessionSystemEvent[] = [
+      { subtype: 'turn_duration', timestamp: '2026-03-01T10:05:00Z', duration_ms: 10000 },
+      { subtype: 'turn_duration', timestamp: '2026-03-01T10:10:00Z', duration_ms: 20000 },
+      { subtype: 'turn_duration', timestamp: '2026-03-01T10:15:00Z', duration_ms: 30000 },
+    ]
+    attributeSystemEvents(convs, events)
+    expect(convs[0].turn_count).toBe(3)
+    expect(convs[0].total_turn_duration_ms).toBe(60000)
+    expect(convs[0].avg_turn_duration_ms).toBe(20000)
+  })
+
+  it('keeps avg_turn_duration_ms null when no turn events', () => {
+    const convs = [makeConv('c0', '2026-03-01T10:00:00Z', '2026-03-01T10:30:00Z')]
+    const events: SessionSystemEvent[] = [
+      { subtype: 'compact_boundary', timestamp: '2026-03-01T10:15:00Z', trigger: 'manual' },
+    ]
+    attributeSystemEvents(convs, events)
+    expect(convs[0].avg_turn_duration_ms).toBeNull()
+  })
+
+  it('counts local_command events', () => {
+    const convs = [makeConv('c0', '2026-03-01T10:00:00Z', '2026-03-01T10:30:00Z')]
+    const events: SessionSystemEvent[] = [
+      { subtype: 'local_command', timestamp: '2026-03-01T10:05:00Z' },
+      { subtype: 'local_command', timestamp: '2026-03-01T10:10:00Z' },
+    ]
+    attributeSystemEvents(convs, events)
+    expect(convs[0].local_command_count).toBe(2)
+  })
+
+  it('attributes events between conversations to the nearest preceding', () => {
+    const convs = [
+      makeConv('c0', '2026-03-01T10:00:00Z', '2026-03-01T10:30:00Z'),
+      makeConv('c1', '2026-03-01T12:00:00Z', '2026-03-01T12:30:00Z'),
+    ]
+    // Event at 11:00 falls between convs — attributed to c0 (preceding)
+    const events: SessionSystemEvent[] = [
+      { subtype: 'compact_boundary', timestamp: '2026-03-01T11:00:00Z', trigger: 'manual' },
+    ]
+    attributeSystemEvents(convs, events)
+    expect(convs[0].compact_count).toBe(1)
+    expect(convs[1].compact_count).toBe(0)
+  })
+
+  it('drops events with no preceding conversation', () => {
+    const convs = [makeConv('c0', '2026-03-01T12:00:00Z', '2026-03-01T12:30:00Z')]
+    const events: SessionSystemEvent[] = [
+      { subtype: 'compact_boundary', timestamp: '2026-03-01T10:00:00Z', trigger: 'manual' },
+    ]
+    attributeSystemEvents(convs, events)
+    expect(convs[0].compact_count).toBe(0)
+  })
+
+  it('drops events with no timestamp', () => {
+    const convs = [makeConv('c0', '2026-03-01T10:00:00Z', '2026-03-01T10:30:00Z')]
+    const events: SessionSystemEvent[] = [
+      { subtype: 'compact_boundary', timestamp: null, trigger: 'manual' },
+    ]
+    attributeSystemEvents(convs, events)
+    expect(convs[0].compact_count).toBe(0)
+  })
+
+  it('is a no-op for empty inputs', () => {
+    const convs: ParsedConversation[] = []
+    expect(() => attributeSystemEvents(convs, [])).not.toThrow()
+
+    const oneConv = [makeConv('c0', '2026-03-01T10:00:00Z', '2026-03-01T10:30:00Z')]
+    attributeSystemEvents(oneConv, [])
+    expect(oneConv[0].compact_count).toBe(0)
+    expect(oneConv[0].avg_turn_duration_ms).toBeNull()
+  })
+
+  it('places events on the correct conversation when ranges are adjacent', () => {
+    const convs = [
+      makeConv('c0', '2026-03-01T10:00:00Z', '2026-03-01T10:30:00Z'),
+      makeConv('c1', '2026-03-01T11:00:00Z', '2026-03-01T11:30:00Z'),
+      makeConv('c2', '2026-03-01T12:00:00Z', '2026-03-01T12:30:00Z'),
+    ]
+    const events: SessionSystemEvent[] = [
+      { subtype: 'turn_duration', timestamp: '2026-03-01T10:15:00Z', duration_ms: 1000 },
+      { subtype: 'turn_duration', timestamp: '2026-03-01T11:15:00Z', duration_ms: 2000 },
+      { subtype: 'turn_duration', timestamp: '2026-03-01T12:15:00Z', duration_ms: 3000 },
+    ]
+    attributeSystemEvents(convs, events)
+    expect(convs[0].total_turn_duration_ms).toBe(1000)
+    expect(convs[1].total_turn_duration_ms).toBe(2000)
+    expect(convs[2].total_turn_duration_ms).toBe(3000)
   })
 })

--- a/vscode-extension/test/unit/errorRecovery.test.ts
+++ b/vscode-extension/test/unit/errorRecovery.test.ts
@@ -59,6 +59,13 @@ function makeConversation(overrides: Partial<ParsedConversation> = {}): ParsedCo
     total_tokens: 2500,
     tokens_per_prompt: 1250,
     cache_hit_rate: 0.4,
+    compact_count: 0,
+    compact_trigger_manual: 0,
+    compact_trigger_auto: 0,
+    turn_count: 0,
+    total_turn_duration_ms: 0,
+    avg_turn_duration_ms: null,
+    local_command_count: 0,
     ...overrides,
   }
 }

--- a/vscode-extension/test/unit/verificationBehaviors.test.ts
+++ b/vscode-extension/test/unit/verificationBehaviors.test.ts
@@ -66,6 +66,13 @@ function makeConversation(overrides: Partial<ParsedConversation> = {}): ParsedCo
     total_tokens: 0,
     tokens_per_prompt: 0,
     cache_hit_rate: 0,
+    compact_count: 0,
+    compact_trigger_manual: 0,
+    compact_trigger_auto: 0,
+    turn_count: 0,
+    total_turn_duration_ms: 0,
+    avg_turn_duration_ms: null,
+    local_command_count: 0,
     ...overrides,
   }
 }

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -168,7 +168,7 @@ CORS is restricted to localhost origins by default. The allowed origin is determ
 
 ## Testing
 
-The webapp has **831 tests** across 13 suites. Run with:
+The webapp has **853 tests** across 13 suites. Run with:
 
 ```bash
 cd webapp

--- a/webapp/conversations.py
+++ b/webapp/conversations.py
@@ -185,6 +185,13 @@ def build_conversations(
             "total_tokens": total_tokens,
             "tokens_per_prompt": tokens_per_prompt,
             "cache_hit_rate": cache_hit_rate,
+            "compact_count": 0,
+            "compact_trigger_manual": 0,
+            "compact_trigger_auto": 0,
+            "turn_count": 0,
+            "total_turn_duration_ms": 0,
+            "avg_turn_duration_ms": None,
+            "local_command_count": 0,
         })
 
     # Assign deterministic IDs
@@ -193,6 +200,56 @@ def build_conversations(
         conv["id"] = f"{project_path_encoded}:conv:{str(i).zfill(pad_width)}"
 
     return conversations
+
+
+def attribute_system_events(
+    conversations: list[dict],
+    system_events: list[dict],
+) -> None:
+    """Attribute timestamped system events to the conversation whose time range
+    contains the event, or — if the event falls between conversations — to the
+    nearest preceding conversation. Events with no preceding conversation are
+    dropped. Mutates conversations in place.
+    """
+    if not conversations or not system_events:
+        return
+
+    sorted_convs = sorted(
+        (c for c in conversations if c.get("started_at")),
+        key=lambda c: c["started_at"],
+    )
+
+    for event in system_events:
+        ts = event.get("timestamp")
+        if not ts:
+            continue
+        target = None
+        for conv in sorted_convs:
+            if conv["started_at"] <= ts:
+                target = conv
+            else:
+                break
+        if target is None:
+            continue
+
+        subtype = event.get("subtype")
+        if subtype == "compact_boundary":
+            target["compact_count"] += 1
+            if event.get("trigger") == "manual":
+                target["compact_trigger_manual"] += 1
+            else:
+                target["compact_trigger_auto"] += 1
+        elif subtype == "turn_duration":
+            target["turn_count"] += 1
+            target["total_turn_duration_ms"] += event.get("duration_ms") or 0
+        elif subtype == "local_command":
+            target["local_command_count"] += 1
+
+    for conv in conversations:
+        if conv["turn_count"] > 0:
+            conv["avg_turn_duration_ms"] = conv["total_turn_duration_ms"] / conv["turn_count"]
+        else:
+            conv["avg_turn_duration_ms"] = None
 
 
 def get_all_conversations(
@@ -251,13 +308,15 @@ def get_all_conversations(
     for result in parsed:
         key = result["project_path_encoded"]
         if key not in by_project:
-            by_project[key] = {"project": result["project"], "encoded": key, "messages": []}
+            by_project[key] = {"project": result["project"], "encoded": key, "messages": [], "system_events": []}
         by_project[key]["messages"].extend(result["messages"])
+        by_project[key]["system_events"].extend(result.get("system_events", []))
 
-    # Build conversations per project
+    # Build conversations per project, then attribute system events
     all_conversations = []
     for info in by_project.values():
         convs = build_conversations(info["messages"], info["project"], info["encoded"], gap_minutes)
+        attribute_system_events(convs, info["system_events"])
         all_conversations.extend(convs)
 
     # Add subagent token usage to conversations.

--- a/webapp/extract_prompts.py
+++ b/webapp/extract_prompts.py
@@ -129,6 +129,7 @@ def parse_session_messages(filepath: Path) -> dict | None:
     is_sidechain = False
 
     messages = []
+    system_events: list[dict] = []
 
     # Deduplication: buffer assistant messages by message.id, emit when ID changes.
     seen_assistant_ids: dict[str, dict] = {}
@@ -144,6 +145,37 @@ def parse_session_messages(filepath: Path) -> dict | None:
 
     for i, msg in enumerate(lines):
         msg_type = msg.get("type", "")
+
+        # Extract `system` subtypes for context/efficiency metrics. Must run
+        # before SKIP_TYPES gate and before metadata defaults so a system row
+        # can't overwrite the canonical sessionId/version/etc. (See #160.)
+        if msg_type == "system":
+            if msg.get("isSidechain") is True:
+                is_sidechain = True
+            subtype = msg.get("subtype")
+            if subtype == "compact_boundary":
+                raw_trigger = (msg.get("compactMetadata") or {}).get("trigger")
+                system_events.append({
+                    "subtype": "compact_boundary",
+                    "timestamp": msg.get("timestamp"),
+                    "trigger": raw_trigger if isinstance(raw_trigger, str) else None,
+                })
+            elif subtype == "turn_duration":
+                duration = msg.get("durationMs")
+                system_events.append({
+                    "subtype": "turn_duration",
+                    "timestamp": msg.get("timestamp"),
+                    "duration_ms": duration if isinstance(duration, (int, float)) else 0,
+                })
+            elif subtype == "local_command":
+                # Pair-emitted with stdout/stderr companion entries; only count invocations.
+                content = msg.get("content")
+                if isinstance(content, str) and "<command-name>" in content:
+                    system_events.append({
+                        "subtype": "local_command",
+                        "timestamp": msg.get("timestamp"),
+                    })
+            continue
 
         if msg_type in SKIP_TYPES:
             continue
@@ -335,6 +367,7 @@ def parse_session_messages(filepath: Path) -> dict | None:
 
     return {
         "messages": messages,
+        "system_events": system_events,
         "session_id": session_id,
         "project": project_name,
         "project_path_encoded": _get_project_path_encoded(filepath),

--- a/webapp/tests/test_conversations.py
+++ b/webapp/tests/test_conversations.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from extract_prompts import parse_session_messages
-from conversations import build_conversations, get_all_conversations
+from conversations import build_conversations, get_all_conversations, attribute_system_events
 
 
 # ─── Helpers ─────────────────────────────────────────────────────────
@@ -927,3 +927,263 @@ class TestBuildConversationsCommandsUsed:
         ]
         convs = build_conversations(messages, "test", "-test", 60)
         assert convs[0]["commands_used"] == []
+
+
+# ─── parse_session_messages — system event extraction ────────────────
+
+
+def _system_msg(subtype, **kwargs):
+    return {
+        "type": "system", "subtype": subtype,
+        "timestamp": kwargs.pop("timestamp", "2026-03-01T10:00:30.000Z"),
+        "sessionId": "sid-1", "cwd": "/home/user/project",
+        "isSidechain": kwargs.pop("isSidechain", False),
+        **kwargs,
+    }
+
+
+class TestParseSessionMessagesSystemEvents:
+    def test_extracts_compact_boundary_with_manual_trigger(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        _write_jsonl(f, [
+            _user_msg("Hello"),
+            _system_msg("compact_boundary", compactMetadata={"trigger": "manual", "preTokens": 100000, "postTokens": 5000}),
+            _assistant_msg(),
+        ])
+        result = parse_session_messages(f)
+        assert result is not None
+        assert len(result["system_events"]) == 1
+        assert result["system_events"][0] == {
+            "subtype": "compact_boundary",
+            "timestamp": "2026-03-01T10:00:30.000Z",
+            "trigger": "manual",
+        }
+
+    def test_preserves_raw_trigger_string(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        _write_jsonl(f, [
+            _user_msg("Hello"),
+            _system_msg("compact_boundary", compactMetadata={"trigger": "auto-threshold"}),
+        ])
+        result = parse_session_messages(f)
+        assert result["system_events"][0]["trigger"] == "auto-threshold"
+
+    def test_handles_missing_compact_metadata(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        _write_jsonl(f, [
+            _user_msg("Hello"),
+            _system_msg("compact_boundary"),
+        ])
+        result = parse_session_messages(f)
+        assert result["system_events"][0] == {
+            "subtype": "compact_boundary",
+            "timestamp": "2026-03-01T10:00:30.000Z",
+            "trigger": None,
+        }
+
+    def test_extracts_turn_duration_with_duration_ms(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        _write_jsonl(f, [
+            _user_msg("Hello"),
+            _system_msg("turn_duration", durationMs=12345, messageCount=8),
+        ])
+        result = parse_session_messages(f)
+        assert result["system_events"][0] == {
+            "subtype": "turn_duration",
+            "timestamp": "2026-03-01T10:00:30.000Z",
+            "duration_ms": 12345,
+        }
+
+    def test_defaults_turn_duration_to_zero_when_missing(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        _write_jsonl(f, [
+            _user_msg("Hello"),
+            _system_msg("turn_duration"),
+        ])
+        result = parse_session_messages(f)
+        assert result["system_events"][0]["duration_ms"] == 0
+
+    def test_extracts_local_command_invocations_only(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        _write_jsonl(f, [
+            _user_msg("Hello"),
+            _system_msg("local_command", content="<command-name>/mcp</command-name>"),
+            _system_msg("local_command", content="<local-command-stdout>output</local-command-stdout>", timestamp="2026-03-01T10:00:31.000Z"),
+            _system_msg("local_command", content="<local-command-stderr>err</local-command-stderr>", timestamp="2026-03-01T10:00:32.000Z"),
+            _system_msg("local_command", content="<command-name>/init</command-name>", timestamp="2026-03-01T10:00:33.000Z"),
+        ])
+        result = parse_session_messages(f)
+        assert len(result["system_events"]) == 2
+        assert all(e["subtype"] == "local_command" for e in result["system_events"])
+
+    def test_skips_out_of_scope_subtypes(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        _write_jsonl(f, [
+            _user_msg("Hello"),
+            _system_msg("api_error", content="rate limited"),
+            _system_msg("away_summary"),
+            _system_msg("informational"),
+            _system_msg("scheduled_task_fire"),
+            _system_msg("stop_hook_summary"),
+        ])
+        result = parse_session_messages(f)
+        assert result["system_events"] == []
+
+    def test_keeps_system_events_out_of_messages_array(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        _write_jsonl(f, [
+            _user_msg("Hello"),
+            _system_msg("compact_boundary", compactMetadata={"trigger": "manual"}),
+            _system_msg("turn_duration", durationMs=1000),
+            _assistant_msg(),
+        ])
+        result = parse_session_messages(f)
+        assert not any(m.get("type") == "system" for m in result["messages"])
+        assert len(result["system_events"]) == 2
+
+    def test_returns_none_for_sidechain_with_system_messages(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        _write_jsonl(f, [
+            _user_msg("Hello", isSidechain=True),
+            _system_msg("compact_boundary", isSidechain=True, compactMetadata={"trigger": "manual"}),
+        ])
+        assert parse_session_messages(f) is None
+
+    def test_detects_sidechain_from_system_message_alone(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        _write_jsonl(f, [
+            _system_msg("compact_boundary", isSidechain=True, compactMetadata={"trigger": "manual"}),
+            _assistant_msg(isSidechain=True),
+        ])
+        assert parse_session_messages(f) is None
+
+    def test_returns_empty_system_events_when_none_present(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        _write_jsonl(f, [
+            _user_msg("Hello"),
+            _assistant_msg(),
+        ])
+        result = parse_session_messages(f)
+        assert result["system_events"] == []
+
+    def test_does_not_overwrite_session_metadata(self, tmp_path):
+        f = tmp_path / "s.jsonl"
+        _write_jsonl(f, [
+            _system_msg("compact_boundary", cwd="/wrong/path", version="wrong",
+                        compactMetadata={"trigger": "manual"}),
+            _user_msg("Hello", cwd="/right/project", version="2.1.100"),
+        ])
+        result = parse_session_messages(f)
+        assert result["project"] == "project"
+        user_message = next(m for m in result["messages"] if m["type"] == "user")
+        assert user_message["claude_code_version"] == "2.1.100"
+
+
+# ─── attribute_system_events ─────────────────────────────────────────
+
+
+def _make_conv(cid, started_at, ended_at):
+    return {
+        "id": cid, "content_hash": "hash", "project": "proj", "project_path_encoded": "-proj",
+        "session_ids": ["s"], "started_at": started_at, "ended_at": ended_at,
+        "user_prompts": ["p"], "prompt_timestamps": [started_at], "prompt_count": 1,
+        "user_message_count": 1, "assistant_message_count": 1, "tool_use_count": 0,
+        "tools_used": [], "commands_used": [], "thinking_count": 0, "used_plan_mode": False,
+        "model": None, "claude_code_version": None, "git_branch": None,
+        "compact_count": 0, "compact_trigger_manual": 0, "compact_trigger_auto": 0,
+        "turn_count": 0, "total_turn_duration_ms": 0, "avg_turn_duration_ms": None,
+        "local_command_count": 0,
+    }
+
+
+class TestAttributeSystemEvents:
+    def test_attributes_compact_to_containing_conversation(self):
+        convs = [_make_conv("c0", "2026-03-01T10:00:00Z", "2026-03-01T10:30:00Z")]
+        events = [{"subtype": "compact_boundary", "timestamp": "2026-03-01T10:15:00Z", "trigger": "manual"}]
+        attribute_system_events(convs, events)
+        assert convs[0]["compact_count"] == 1
+        assert convs[0]["compact_trigger_manual"] == 1
+        assert convs[0]["compact_trigger_auto"] == 0
+
+    def test_buckets_non_manual_as_auto(self):
+        convs = [_make_conv("c0", "2026-03-01T10:00:00Z", "2026-03-01T10:30:00Z")]
+        events = [
+            {"subtype": "compact_boundary", "timestamp": "2026-03-01T10:15:00Z", "trigger": "auto-threshold"},
+            {"subtype": "compact_boundary", "timestamp": "2026-03-01T10:20:00Z", "trigger": None},
+        ]
+        attribute_system_events(convs, events)
+        assert convs[0]["compact_count"] == 2
+        assert convs[0]["compact_trigger_manual"] == 0
+        assert convs[0]["compact_trigger_auto"] == 2
+
+    def test_aggregates_turn_duration_and_computes_avg(self):
+        convs = [_make_conv("c0", "2026-03-01T10:00:00Z", "2026-03-01T10:30:00Z")]
+        events = [
+            {"subtype": "turn_duration", "timestamp": "2026-03-01T10:05:00Z", "duration_ms": 10000},
+            {"subtype": "turn_duration", "timestamp": "2026-03-01T10:10:00Z", "duration_ms": 20000},
+            {"subtype": "turn_duration", "timestamp": "2026-03-01T10:15:00Z", "duration_ms": 30000},
+        ]
+        attribute_system_events(convs, events)
+        assert convs[0]["turn_count"] == 3
+        assert convs[0]["total_turn_duration_ms"] == 60000
+        assert convs[0]["avg_turn_duration_ms"] == 20000
+
+    def test_avg_turn_duration_null_when_no_turn_events(self):
+        convs = [_make_conv("c0", "2026-03-01T10:00:00Z", "2026-03-01T10:30:00Z")]
+        events = [{"subtype": "compact_boundary", "timestamp": "2026-03-01T10:15:00Z", "trigger": "manual"}]
+        attribute_system_events(convs, events)
+        assert convs[0]["avg_turn_duration_ms"] is None
+
+    def test_counts_local_command_events(self):
+        convs = [_make_conv("c0", "2026-03-01T10:00:00Z", "2026-03-01T10:30:00Z")]
+        events = [
+            {"subtype": "local_command", "timestamp": "2026-03-01T10:05:00Z"},
+            {"subtype": "local_command", "timestamp": "2026-03-01T10:10:00Z"},
+        ]
+        attribute_system_events(convs, events)
+        assert convs[0]["local_command_count"] == 2
+
+    def test_attributes_between_conversations_to_nearest_preceding(self):
+        convs = [
+            _make_conv("c0", "2026-03-01T10:00:00Z", "2026-03-01T10:30:00Z"),
+            _make_conv("c1", "2026-03-01T12:00:00Z", "2026-03-01T12:30:00Z"),
+        ]
+        events = [{"subtype": "compact_boundary", "timestamp": "2026-03-01T11:00:00Z", "trigger": "manual"}]
+        attribute_system_events(convs, events)
+        assert convs[0]["compact_count"] == 1
+        assert convs[1]["compact_count"] == 0
+
+    def test_drops_events_with_no_preceding_conversation(self):
+        convs = [_make_conv("c0", "2026-03-01T12:00:00Z", "2026-03-01T12:30:00Z")]
+        events = [{"subtype": "compact_boundary", "timestamp": "2026-03-01T10:00:00Z", "trigger": "manual"}]
+        attribute_system_events(convs, events)
+        assert convs[0]["compact_count"] == 0
+
+    def test_drops_events_with_no_timestamp(self):
+        convs = [_make_conv("c0", "2026-03-01T10:00:00Z", "2026-03-01T10:30:00Z")]
+        events = [{"subtype": "compact_boundary", "timestamp": None, "trigger": "manual"}]
+        attribute_system_events(convs, events)
+        assert convs[0]["compact_count"] == 0
+
+    def test_no_op_for_empty_inputs(self):
+        attribute_system_events([], [])  # should not raise
+        convs = [_make_conv("c0", "2026-03-01T10:00:00Z", "2026-03-01T10:30:00Z")]
+        attribute_system_events(convs, [])
+        assert convs[0]["compact_count"] == 0
+        assert convs[0]["avg_turn_duration_ms"] is None
+
+    def test_places_events_correctly_across_adjacent_ranges(self):
+        convs = [
+            _make_conv("c0", "2026-03-01T10:00:00Z", "2026-03-01T10:30:00Z"),
+            _make_conv("c1", "2026-03-01T11:00:00Z", "2026-03-01T11:30:00Z"),
+            _make_conv("c2", "2026-03-01T12:00:00Z", "2026-03-01T12:30:00Z"),
+        ]
+        events = [
+            {"subtype": "turn_duration", "timestamp": "2026-03-01T10:15:00Z", "duration_ms": 1000},
+            {"subtype": "turn_duration", "timestamp": "2026-03-01T11:15:00Z", "duration_ms": 2000},
+            {"subtype": "turn_duration", "timestamp": "2026-03-01T12:15:00Z", "duration_ms": 3000},
+        ]
+        attribute_system_events(convs, events)
+        assert convs[0]["total_turn_duration_ms"] == 1000
+        assert convs[1]["total_turn_duration_ms"] == 2000
+        assert convs[2]["total_turn_duration_ms"] == 3000


### PR DESCRIPTION
## Summary

Closes #160. Extracts three `system` JSONL subtypes (`compact_boundary`, `turn_duration`, `local_command`) into per-conversation metrics. Lays the data foundation for the v1.3 CCA radar (Phase 3) and other downstream consumers.

## What changes for users

Each conversation now exposes seven new fields (zero-defaulted, always present):

| Field | What it measures |
|-------|------------------|
| `compact_count` | Total `compact_boundary` events in the conversation |
| `compact_trigger_manual` / `compact_trigger_auto` | Breakdown by trigger (manual vs anything else) |
| `turn_count` | Number of `turn_duration` events |
| `total_turn_duration_ms`, `avg_turn_duration_ms` | Sum and mean of turn durations (avg is `null` when `turn_count == 0`) |
| `local_command_count` | Slash-command invocations from the system stream (`<command-name>` entries; stdout/stderr companions filtered) |

Smoke test against a real session: 32 events extracted (6 local_commands, 25 turn_durations, 1 manual compact_boundary). Sample turn duration: 148–425s, sample compact: `trigger='manual'`.

## Architecture (per architect review)

Two architect reviews were run on this issue — the first set scope, the second validated the implementation plan. Both posted to issue #160. Key constraints satisfied:

- **System extraction runs as the first statement of the parse loop**, before `SKIP_TYPES` and metadata defaults — a system row can't overwrite canonical `sessionId`/`version`/etc.
- **`system` stays in `SKIP_TYPES`** as a guardrail in case the explicit branch is ever refactored.
- **System events do NOT enter the `TimestampedMessage` pipeline** — they live in a sidecar `system_events: SessionSystemEvent[]` array on `SessionMessagesResult`. Gap-based conversation splitting and `started_at`/`ended_at` ranges are unaffected.
- **Attribution is timestamp-based**: each event maps to the conversation whose `[started_at, ended_at]` contains it. Events between conversations attach to the *nearest preceding* conversation (matches how `compact_boundary` actually fires — at the end of the prior context). Events with no preceding conversation are dropped.
- **Raw `trigger` string is preserved by the parser**; the conversation builder buckets it into `_manual` vs `_auto`. Future-proofs against new trigger values.

## Out of scope (deferred)

- `progress`, `hook_progress`, `agent_progress`, `mcp_progress`, `bash_progress` — these appear *only* in `subagents/agent-*.jsonl` files (verified by inspecting real data), which are already filtered out as sidechain. The natural home is #255 (subagent parser story).
- `compactMetadata.preTokens` / `postTokens` / `durationMs` — Anthropic-internal schema, treat as unstable. Only `trigger` is extracted.
- `parseSessionFile` / `parse_session_file` (legacy parsers) intentionally unchanged — `ParsedSession` consumers don't expect these fields.
- Frontend / aggregation / scoring consumers wire up in follow-up PRs (CCA radar, etc.). This PR is data-layer only.

## Test plan

- [x] Extension: `npm test` — 1019 passing (was 997, +22 new tests across 2 describe blocks)
- [x] Webapp: `uv run pytest tests/ --ignore=tests/e2e` — 853 passing (was 831, +22 new tests across 2 test classes)
- [x] Smoke test on real JSONL with known compact/turn events — extraction matches expected payloads
- [x] All three test factories that build `ParsedConversation` (`errorRecovery`, `verificationBehaviors`, `agentMetrics`) updated to include new required fields
- [x] CI green

## Architect review trail

- Initial scope review: https://github.com/frederick-douglas-pearce/codefluent/issues/160#issuecomment-4405316XXX *(narrowed scope, deferred progress events)*
- Plan review: https://github.com/frederick-douglas-pearce/codefluent/issues/160#issuecomment-4405418107 *(validated design, flagged loop ordering blocker — addressed)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)